### PR TITLE
chore: Use custom release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,50 @@ on:
 permissions:
   id-token: write
   contents: read
+  actions: read
 
 jobs:
   release:
-    uses: cloudscape-design/actions/.github/workflows/release.yml@main
-    secrets: inherit
-    with:
-      publish-packages: lib/components,lib/components-themeable
-      skip-test: true
+    concurrency: release-${{ github.ref }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm install
+      - run: npm run build
+      - name: Upload release artifacts
+        id: upload-release
+        uses: actions/upload-artifact@v4
+        with:
+          name: release
+          path: lib
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ inputs.role-to-assume || secrets.AWS_CODEARTIFACT_ROLE }}
+          aws-region: us-west-2
+      - name: Run CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{ inputs.project-name || secrets.AWS_CODEBUILD_PROJECT_NAME ||  'Importer-v2' }}
+          disable-source-override: true
+          hide-cloudwatch-logs: true
+          env-vars-for-codebuild: |
+            AWSUI_GITHUB_ARTIFACT_ID,
+            AWSUI_GITHUB_BRANCH_NAME,
+            AWSUI_GITHUB_COMMIT_SHA,
+            AWSUI_GITHUB_COMMIT_MESSAGE,
+            AWSUI_GITHUB_REPOSITORY_NAME,
+            AWSUI_GITHUB_TOKEN
+        env:
+          AWSUI_GITHUB_ARTIFACT_ID: ${{ steps.upload-release.outputs.artifact-id }}
+          AWSUI_GITHUB_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          AWSUI_GITHUB_COMMIT_SHA: ${{ github.sha }}
+          AWSUI_GITHUB_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          AWSUI_GITHUB_REPOSITORY_NAME: ${{ github.event.repository.full_name }}
+          AWSUI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

See https://github.com/cloudscape-design/actions/pull/75

A workflow being called by another workflow cannot use permissions that the workflow calling it does not have. Therefore adding `actions: read` permissions to the upstream workflow would break the release workflow in multiple packages.

This PR can be reverted when publishing the package, or even before —for the sake of building the internal package we just need one successful release from main.

### How has this been tested?

- In my dev branch: https://github.com/cloudscape-design/chart-components/actions/runs/14712682191
- In the charts-0.1 branch, where I already pushed this change: https://github.com/cloudscape-design/chart-components/actions/runs/14725157373

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
