### PR TITLE
chore: Migrate to the new documenter API

### DIFF
--- a/src/__tests__/documenter.test.ts
+++ b/src/__tests__/documenter.test.ts
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import { expect, test } from "vitest";
 
-import { getAllComponents, requireComponentDefinition } from "./utils";
-
+import componentDefinitions from "../../lib/components/internal/api-docs/components";
+import { getAllComponents } from "./utils";
 test.each<string>(getAllComponents())(`definition for %s matches the snapshot`, (componentName: string) => {
-  const definition = requireComponentDefinition(componentName);
+  const definition = componentDefinitions[componentName];
 
   // overriding with a fake value so that when there are icon changes in components this test doesn't block it
-  const iconNameDefinition = definition.properties.filter(({ name }: { name: string }) => name === "iconName");
-  if (iconNameDefinition && iconNameDefinition[0]) {
-    iconNameDefinition[0].inlineType.values = "comes from @cloudscape-design/components";
+  const iconNameDefinition = definition.properties.find(({ name }: { name: string }) => name === "iconName");
+  if (iconNameDefinition && iconNameDefinition.inlineType?.type === "union") {
+    iconNameDefinition.inlineType.values = ["comes from @cloudscape-design/components"];
   }
   expect(definition).toMatchSnapshot(componentName);
 });

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -6,7 +6,6 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const componentsDir = path.resolve(__dirname, "../../lib/components");
-const definitionsDir = path.resolve(__dirname, "../../lib/components/internal/api-docs/components");
 
 export function getAllComponents(): string[] {
   return fs
@@ -19,11 +18,6 @@ export function getAllComponents(): string[] {
         !name.includes("LICENSE") &&
         !name.includes("NOTICE"),
     );
-}
-
-export function requireComponentDefinition(componentName: string) {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  return require(path.join(definitionsDir, componentName));
 }
 
 export async function requireComponent(componentName: string) {


### PR DESCRIPTION
### Description

Same as https://github.com/cloudscape-design/components/pull/3475 and https://github.com/cloudscape-design/chat-components/pull/72 but for this package

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
