### PR TITLE
fix: use custom useId hook for compatibility with older react versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@cloudscape-design/components": "^3",
     "@cloudscape-design/design-tokens": "^3",
     "highcharts": "^12.2.0",
-    "react": ">=18.2.0"
+    "react": ">=16.0.0"
   },
   "devDependencies": {
     "@cloudscape-design/browser-test-tools": "^3.0.4",

--- a/src/core/chart-core.tsx
+++ b/src/core/chart-core.tsx
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useId, useRef } from "react";
+import { useRef } from "react";
 import clsx from "clsx";
 import type Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 
-import { getIsRtl, useMergeRefs } from "@cloudscape-design/component-toolkit/internal";
+import { getIsRtl, useMergeRefs, useUniqueId } from "@cloudscape-design/component-toolkit/internal";
 import { isDevelopment } from "@cloudscape-design/component-toolkit/internal";
 import Spinner from "@cloudscape-design/components/spinner";
 
@@ -65,7 +65,7 @@ export function InternalCoreChart({
   const highcharts = rest.highcharts as null | typeof Highcharts;
 
   const settings = {
-    chartId: useId(),
+    chartId: useUniqueId(),
     noDataEnabled: !!noDataOptions,
     legendEnabled: legendOptions?.enabled !== false,
     tooltipEnabled: tooltipOptions?.enabled !== false,


### PR DESCRIPTION
### Description

Introduces a new useId hook to automatically generate unique, stable IDs. It solves the challenge of inconsistent IDs during server-side rendering and hydration by initially rendering empty IDs and then patching them on the first client-side render. Using this hook instead of the one provided by React 18 ensures compatibility with older React versions that don't natively support ID generation.

References:
- https://github.com/guidari/carbon/blob/4e293260fc4c0b8172c607e3ee4770355f662296/packages/react/src/internal/useId.js
- https://github.com/reach/reach-ui/blob/86a046f54d53b6420e392b3fa56dd991d9d4e458/packages/auto-id/src/index.ts
- https://github.com/floating-ui/floating-ui/blob/%40floating-ui/utils%400.2.5/packages/react/src/hooks/useId.ts

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
