### PR TITLE
feat: add navigator prop to core chart

### DIFF
--- a/src/core/__tests__/chart-core-container.test.tsx
+++ b/src/core/__tests__/chart-core-container.test.tsx
@@ -6,7 +6,7 @@ import highcharts from "highcharts";
 import { renderChart } from "./common";
 
 describe("CoreChart: container", () => {
-  test("renders chart header, filter, vertical axis title, chart plot, legend, and footer", () => {
+  test("renders chart header, filter, vertical axis title, chart plot, navigator, legend, and footer", () => {
     const { wrapper } = renderChart({
       highcharts,
       options: {
@@ -20,6 +20,7 @@ describe("CoreChart: container", () => {
         seriesFilter: true,
         additionalFilters: "Additional filter",
       },
+      navigator: <div>Navigator content</div>,
       legend: { title: "Legend title" },
       footer: { content: "Custom footer" },
       i18nStrings: { seriesFilterLabel: "Series filter" },
@@ -43,6 +44,10 @@ describe("CoreChart: container", () => {
     const chartPlot = wrapper.findChartPlot()!.getElement();
     expect(chartPlot).toHaveTextContent("X-axis title");
     expect(chartPlot.compareDocumentPosition(verticalAxisTitle)).toBe(Node.DOCUMENT_POSITION_PRECEDING);
+
+    const navigator = wrapper.findNavigator()!.getElement();
+    expect(navigator.textContent).toBe("Navigator content");
+    expect(navigator.compareDocumentPosition(chartPlot)).toBe(Node.DOCUMENT_POSITION_PRECEDING);
 
     const legend = wrapper.findLegend()!.getElement();
     expect(legend.textContent).toBe("Legend titleSeries 1");

--- a/src/core/chart-container.tsx
+++ b/src/core/chart-container.tsx
@@ -24,6 +24,7 @@ interface ChartContainerProps {
   verticalAxisTitlePlacement: "top" | "side";
   header?: React.ReactNode;
   filter?: React.ReactNode;
+  navigator?: React.ReactNode;
   legend?: React.ReactNode;
   legendPosition: "bottom" | "side";
   footer?: React.ReactNode;
@@ -42,6 +43,7 @@ export function ChartContainer({
   footer,
   legend,
   legendPosition,
+  navigator,
   fitHeight,
   chartHeight,
   chartMinHeight,
@@ -91,6 +93,7 @@ export function ChartContainer({
       )}
 
       <div ref={refs.footer}>
+        {navigator && <div className={testClasses["chart-navigator"]}>{navigator}</div>}
         {legendPosition === "bottom" && legend}
         {footer}
       </div>

--- a/src/core/chart-core.tsx
+++ b/src/core/chart-core.tsx
@@ -44,6 +44,7 @@ export function InternalCoreChart({
   chartMinWidth,
   tooltip: tooltipOptions,
   noData: noDataOptions,
+  navigator,
   legend: legendOptions,
   fallback = <Spinner />,
   callback,
@@ -278,6 +279,7 @@ export function InternalCoreChart({
             </>
           );
         }}
+        navigator={navigator}
         legend={
           settings.legendEnabled ? (
             <ChartLegend {...legendOptions} position={legendPosition} api={api} i18nStrings={i18nStrings} />

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -237,6 +237,11 @@ export interface CoreChartProps
    */
   header?: CoreHeaderOptions;
   /**
+   * Prop for passing a custom navigation control component to be rendered with the chart.
+   * Use this property to add timeline navigation, range selectors, or other custom navigation elements.
+   */
+  navigator?: React.ReactNode;
+  /**
    * A custom slot below the chart plot and legend.
    */
   footer?: CoreFooterOptions;

--- a/src/core/test-classes/styles.scss
+++ b/src/core/test-classes/styles.scss
@@ -14,6 +14,7 @@
 .chart-filters-additional,
 .chart-header,
 .chart-footer,
+.chart-navigator,
 .axis-x,
 .axis-x-title,
 .axis-y,

--- a/src/test-utils/dom/core/index.ts
+++ b/src/test-utils/dom/core/index.ts
@@ -16,6 +16,10 @@ export default class CoreChartWrapper extends BaseChartWrapper {
     return this.findByClassName(testClasses["chart-footer"]);
   }
 
+  public findNavigator(): null | ElementWrapper {
+    return this.findByClassName(testClasses["chart-navigator"]);
+  }
+
   public findVerticalAxisTitle(): null | ElementWrapper {
     return (
       this.findByClassName(testClasses["axis-vertical-title"]) ??


### PR DESCRIPTION
### Description

Added a new `navigator` prop to the core chart component that allows custom navigation controls to be rendered with the chart.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
