### PR TITLE
feat: scroll into view highlighted legend item

### DIFF
--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -53,11 +53,26 @@ export const ChartLegend = ({
     if (highlightedIndex === -1) {
       return;
     }
+
     scrollIntoViewControl.cancelPrevious();
-    scrollIntoViewControl.call(
-      () => segmentsRef.current?.[highlightedIndex]?.scrollIntoView({ behavior: "smooth", block: "center" }),
-      100,
-    );
+    scrollIntoViewControl.call(() => {
+      const container = containerRef.current;
+      const element = segmentsRef.current?.[highlightedIndex];
+      if (!container || !element) {
+        return;
+      }
+
+      const elementRect = element.getBoundingClientRect();
+      const containerRect = container.getBoundingClientRect();
+      const isVisible = elementRect.top >= containerRect.top && elementRect.bottom <= containerRect.bottom;
+
+      if (!isVisible) {
+        const elementCenter = elementRect.top + elementRect.height / 2;
+        const containerCenter = containerRect.top + containerRect.height / 2;
+        const top = container.scrollTop + (elementCenter - containerCenter);
+        container.scrollTo({ top, behavior: "smooth" });
+      }
+    }, 100);
   }, [items, scrollIntoViewControl]);
 
   const showHighlight = (itemId: string) => {

--- a/src/internal/components/chart-legend/styles.scss
+++ b/src/internal/components/chart-legend/styles.scss
@@ -12,6 +12,9 @@
   @include styles.styles-reset;
   @include styles.default-text-style;
 
+  overflow: auto;
+  max-height: inherit;
+
   &:focus {
     outline: none;
   }


### PR DESCRIPTION
### Description

Improves the chart legends by automatically scrolling into view the highlighted item.

### How has this been tested?

1st Commit:

https://github.com/user-attachments/assets/5f83b515-01b4-4b5a-93cf-338a330d40ba

2nd Commit:

https://github.com/user-attachments/assets/4fd0faf9-6f8e-41ef-8154-b85dfeb0ccce

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
