### PR TITLE
fix: add highlight status to key

### DIFF
--- a/src/internal/components/series-details/index.tsx
+++ b/src/internal/components/series-details/index.tsx
@@ -69,7 +69,11 @@ function ChartSeriesDetails(
       <ul className={clsx(styles.list, compactList && styles.compact)}>
         {details.map(({ key, value, marker, isDimmed, subItems, expandableId, description, highlighted }, index) => (
           <li
-            key={[index, highlighted].join(",")}
+            // Include 'highlighted' in the key to force React re-render when highlight state changes.
+            // Without this, the highlight indicator div may not be removed when cursor moves away from data points
+            // due to React's reconciliation algorithm not detecting the state change in complex data scenarios.
+            // This ensures proper cleanup of visual highlight indicators.
+            key={[index, highlighted].join("-")}
             className={clsx({
               [styles.dimmed]: isDimmed,
               [styles["list-item"]]: true,

--- a/src/internal/components/series-details/index.tsx
+++ b/src/internal/components/series-details/index.tsx
@@ -69,7 +69,7 @@ function ChartSeriesDetails(
       <ul className={clsx(styles.list, compactList && styles.compact)}>
         {details.map(({ key, value, marker, isDimmed, subItems, expandableId, description, highlighted }, index) => (
           <li
-            key={index}
+            key={[index, highlighted].join(",")}
             className={clsx({
               [styles.dimmed]: isDimmed,
               [styles["list-item"]]: true,


### PR DESCRIPTION
### Description

This change fixes a React key prop issue in the series details component by incorporating the `highlighted` status into the key generation. Previously, the component was using only the array index as the key, which was causing React rendering issues when items change their highlight state without changing position.

The fix ensures that when an item's highlight status changes, React properly re-renders the component by treating it as a new element, preventing potential UI inconsistencies or stale state issues.

Related links, issue #, if available: n/a

### How has this been tested?

This change has been tested by:
- Verifying that the component still renders correctly with the new key structure
- Confirming that highlight state changes now properly trigger re-renders
- Testing that the comma-separated key format doesn't cause conflicts

Reviewers can test these changes by:
1. Interacting with chart components that use series details
2. Toggling highlight states on chart series
3. Verifying that visual updates occur immediately and correctly

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
