### PR TITLE
chore: Alternative column series highlight effect

### DIFF
--- a/pages/06-visual-tests/column-hover.page.tsx
+++ b/pages/06-visual-tests/column-hover.page.tsx
@@ -19,19 +19,22 @@ const domain = [
 export default function () {
   return (
     <Page title="Column series hover visual regression page">
-      <ColumnLayout columns={2}>
+      <ColumnLayout columns={3}>
         <PageSection>
-          <Chart stacked={false} />
+          <Chart type="stacked" />
         </PageSection>
         <PageSection>
-          <Chart stacked={true} />
+          <Chart type="grouped" />
+        </PageSection>
+        <PageSection>
+          <Chart type="single" />
         </PageSection>
       </ColumnLayout>
     </Page>
   );
 }
 
-function Chart({ stacked }: { stacked: boolean }) {
+function Chart({ type }: { type: "single" | "stacked" | "grouped" }) {
   const { chartProps } = useChartSettings();
   return (
     <CoreChart
@@ -40,29 +43,29 @@ function Chart({ stacked }: { stacked: boolean }) {
       legend={{ enabled: false }}
       tooltip={{ placement: "outside" }}
       options={{
-        plotOptions: { series: { stacking: stacked ? "normal" : undefined } },
+        plotOptions: { series: { stacking: type === "stacked" ? "normal" : undefined } },
         series: [
           {
             name: "Severe",
-            type: "column",
+            type: "column" as const,
             data: [22, 28, 25, 13, 28],
           },
           {
             name: "Moderate",
-            type: "column",
+            type: "column" as const,
             data: [18, 21, 22, 0, 1],
           },
           {
             name: "Low",
-            type: "column",
+            type: "column" as const,
             data: [17, 19, 18, 17, 15],
           },
           {
             name: "Unclassified",
-            type: "column",
+            type: "column" as const,
             data: [24, 18, 16, 14, 16],
           },
-        ],
+        ].slice(0, type === "single" ? 1 : 4),
         xAxis: [
           {
             type: "category",
@@ -75,7 +78,8 @@ function Chart({ stacked }: { stacked: boolean }) {
       callback={(api) => {
         setTimeout(() => {
           if (api.chart.series) {
-            const point = api.chart.series[1].data.find((p) => p.x === 2)!;
+            const seriesIndex = Math.min(api.chart.series.length - 1, 1);
+            const point = api.chart.series[seriesIndex].data.find((p) => p.x === 2)!;
             api.highlightChartPoint(point);
           }
         }, 0);

--- a/pages/06-visual-tests/column-hover.page.tsx
+++ b/pages/06-visual-tests/column-hover.page.tsx
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+
+import CoreChart from "../../lib/components/internal-do-not-use/core-chart";
+import { dateFormatter } from "../common/formatters";
+import { useChartSettings } from "../common/page-settings";
+import { Page, PageSection } from "../common/templates";
+
+const domain = [
+  new Date(1601071200000),
+  new Date(1601078400000),
+  new Date(1601085600000),
+  new Date(1601092800000),
+  new Date(1601100000000),
+];
+
+export default function () {
+  return (
+    <Page title="Column series hover visual regression page">
+      <ColumnLayout columns={2}>
+        <PageSection>
+          <Chart stacked={false} />
+        </PageSection>
+        <PageSection>
+          <Chart stacked={true} />
+        </PageSection>
+      </ColumnLayout>
+    </Page>
+  );
+}
+
+function Chart({ stacked }: { stacked: boolean }) {
+  const { chartProps } = useChartSettings();
+  return (
+    <CoreChart
+      highcharts={chartProps.cartesian.highcharts}
+      ariaLabel="Bar chart"
+      legend={{ enabled: false }}
+      tooltip={{ placement: "outside" }}
+      options={{
+        plotOptions: { series: { stacking: stacked ? "normal" : undefined } },
+        series: [
+          {
+            name: "Severe",
+            type: "column",
+            data: [22, 28, 25, 13, 28],
+          },
+          {
+            name: "Moderate",
+            type: "column",
+            data: [18, 21, 22, 0, 1],
+          },
+          {
+            name: "Low",
+            type: "column",
+            data: [17, 19, 18, 17, 15],
+          },
+          {
+            name: "Unclassified",
+            type: "column",
+            data: [24, 18, 16, 14, 16],
+          },
+        ],
+        xAxis: [
+          {
+            type: "category",
+            title: { text: "Time (UTC)" },
+            categories: domain.map((date) => dateFormatter(date.getTime())),
+          },
+        ],
+        yAxis: [{ title: { text: "Error count" } }],
+      }}
+      callback={(api) => {
+        setTimeout(() => {
+          if (api.chart.series) {
+            const point = api.chart.series[1].data.find((p) => p.x === 2)!;
+            api.highlightChartPoint(point);
+          }
+        }, 0);
+      }}
+    />
+  );
+}

--- a/src/core/chart-api/chart-extra-highlight.ts
+++ b/src/core/chart-api/chart-extra-highlight.ts
@@ -62,7 +62,7 @@ export class ChartExtraHighlight {
     });
     for (const s of this.context.chart().series) {
       this.setSeriesState(s, includedSeries.has(s) ? "" : "inactive");
-      // We use special handling for column- series to make stacks or groups of columns that have a shared X highlighted.
+      // For column series we ensure only one group/stack that matches selected X is highlighted.
       // See: https://github.com/highcharts/highcharts/issues/23076.
       if (s.type === "column") {
         for (const d of s.data) {
@@ -86,10 +86,10 @@ export class ChartExtraHighlight {
         }
         this.setPointState(point, "hover");
       }
-      // We override point state that could have been set for columns using this.highlightChartGroup().
+      // For column series we ensure only one group/stack that matches selected X is highlighted.
       else if (s.type === "column") {
         for (const d of s.data) {
-          this.setPointState(d, "");
+          this.setPointState(d, d === point ? "hover" : "inactive");
         }
       }
     }

--- a/src/internal/chart-styles.ts
+++ b/src/internal/chart-styles.ts
@@ -133,7 +133,7 @@ export const seriesDataLabelsCss: Highcharts.CSSObject = {
   textOutline: "",
 };
 
-export const seriesOpacityInactive = 0.2;
+export const seriesOpacityInactive = 0.3;
 
 export const verticalAxisTitleBlockSize = 24;
 export const verticalAxisTitleMargin = 4;


### PR DESCRIPTION
### Description

Change column series highlight effect so that both group and point selection modes only highlight a single column stack/group.

See: [dNzKAmh3QYeh]

### How has this been tested?

* New unit test
* The visual regression tests show flakiness, but no regression

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
