### PR TITLE
feat: add support for dual axis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1076,6 +1076,205 @@
         "node": ">=18"
       }
     },
+    "node_modules/@cloudscape-design/browser-test-tools": {
+      "version": "3.0.96",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/browser-test-tools/-/browser-test-tools-3.0.96.tgz",
+      "integrity": "sha512-/gaRYYRzaCyVds8UNb83u3RZ+r/Hv7PrBzJHwOb14wq7yxLVwLVCmi3Wa3c5qFrxwuseI111Uz237sshFFJuAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-device-farm": "^3.623.0",
+        "@types/pngjs": "^6.0.4",
+        "@wdio/globals": "^9.7.0",
+        "@wdio/types": "^9.6.3",
+        "get-stream": "^6.0.1",
+        "lodash": "^4.17.21",
+        "p-retry": "^4.6.2",
+        "pixelmatch": "^5.3.0",
+        "pngjs": "^6.0.0",
+        "wait-on": "^8.0.3",
+        "webdriverio": "^9.7.0"
+      }
+    },
+    "node_modules/@cloudscape-design/build-tools": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/build-tools/-/build-tools-3.0.13.tgz",
+      "integrity": "sha512-kdt0/DtjGPhBJIsJq04+9R+zalPl3OqDmuTUyOuTHvprFGUDNz1Gs0z6cjKqwOVNUpJmybDd1W922e49wjXbew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^10.0.1"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.8.1"
+      }
+    },
+    "node_modules/@cloudscape-design/code-view": {
+      "version": "3.0.67",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/code-view/-/code-view-3.0.67.tgz",
+      "integrity": "sha512-jgE5J76hyypePEqg2fQh1hw81IlrHKplOfxveD70qwa4Iia9FWddV9w/+FdTEBgCjZ42aL4zGZFmIIOPGkrQPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cloudscape-design/component-toolkit": "^1.0.0-beta",
+        "ace-code": "^1.32.3",
+        "clsx": "^1.2.1"
+      },
+      "peerDependencies": {
+        "@cloudscape-design/components": "^3",
+        "react": ">=18.2.0"
+      }
+    },
+    "node_modules/@cloudscape-design/collection-hooks": {
+      "version": "1.0.73",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/collection-hooks/-/collection-hooks-1.0.73.tgz",
+      "integrity": "sha512-eWj+K2PR4RLSOxDl2fYNPAm+9cqvPr8va5KXthhC/K4tWDSqwFliG6x4vqgdmvifyNJIviD80p6zm8vdk5X27w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@cloudscape-design/component-toolkit": {
+      "version": "1.0.0-beta.109",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.109.tgz",
+      "integrity": "sha512-jSEYlMlLamMLGtot1bWLHKz2GAuPLECLJFaL3FctOM5HR2xT3z5L0J7OckZ+/gNl87V3B7sp4qnaEPBA23rgJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.3.1",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@cloudscape-design/components": {
+      "version": "3.0.1027",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.1027.tgz",
+      "integrity": "sha512-y7xYimFI8u7X+2/P8ftP8CRbiIaUsAcZZBZiHZ1HDNzJZpnY+k823emCpVwBKMNivvVmG3Kelj9o5rYjR85tKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cloudscape-design/collection-hooks": "^1.0.0",
+        "@cloudscape-design/component-toolkit": "^1.0.0-beta",
+        "@cloudscape-design/test-utils-core": "^1.0.0",
+        "@cloudscape-design/theming-runtime": "^1.0.0",
+        "@dnd-kit/core": "^6.0.8",
+        "@dnd-kit/sortable": "^7.0.2",
+        "@dnd-kit/utilities": "^3.2.1",
+        "@juggle/resize-observer": "^3.3.1",
+        "ace-builds": "^1.34.0",
+        "balanced-match": "^1.0.2",
+        "clsx": "^1.1.0",
+        "d3-shape": "^1.3.7",
+        "date-fns": "^2.25.0",
+        "intl-messageformat": "^10.3.1",
+        "mnth": "^2.0.0",
+        "react-keyed-flatten-children": "^2.2.1",
+        "react-transition-group": "^4.4.2",
+        "tslib": "^2.4.0",
+        "weekstart": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@cloudscape-design/components/node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/@cloudscape-design/design-tokens": {
+      "version": "3.0.59",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/design-tokens/-/design-tokens-3.0.59.tgz",
+      "integrity": "sha512-AYbfj/AT3coKl9UlaMEEJo6BDgcX01GjVCipR+d8IBMh1Imq9gEGmyZdPQjywo4FdRx7ZCqvHdqYCd6QPCvA9g==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@cloudscape-design/documenter": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/documenter/-/documenter-1.0.48.tgz",
+      "integrity": "sha512-Ppzy16NR8FHJMSlO51MehDVx2DBjSExV9nads2mQiPk0FPrcpcI2jjgVlV0tn8zP3u+Nr080xM5JrqB+44t3cQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "change-case": "^4.1.1",
+        "micromatch": "^4.0.8",
+        "pathe": "^1.1.2",
+        "typedoc": "~0.19.2"
+      }
+    },
+    "node_modules/@cloudscape-design/global-styles": {
+      "version": "1.0.44",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.44.tgz",
+      "integrity": "sha512-cQmZ3tsbbMv4QZll0+NzmlUHjmQj0C+9s9nIf1KyV/sdVFGfeFLbV4K4cMmWeu2kOwg1fAE1QkjTI96SpUGM9w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@cloudscape-design/test-utils-converter": {
+      "version": "1.0.59",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/test-utils-converter/-/test-utils-converter-1.0.59.tgz",
+      "integrity": "sha512-C1l0ccyrdWBFFdxOK+LuLE/W4q89zYrPYcwU/8RTmoj09SbSzqn3emIJ/SdF+zXl7ZOwfxoRpnE66JNGHUs65Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "^7.16.0",
+        "@babel/plugin-syntax-decorators": "^7.16.0",
+        "@babel/plugin-syntax-typescript": "^7.16.0",
+        "glob": "^7.2.0"
+      }
+    },
+    "node_modules/@cloudscape-design/test-utils-core": {
+      "version": "1.0.59",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/test-utils-core/-/test-utils-core-1.0.59.tgz",
+      "integrity": "sha512-HtNYw0+hXWbOAyR3iA81VVZtHnzFZ9EUp9vShDYVDVSH5EwdlI3O589HjOU6jujojed7T57v3BLM3RK4cTekhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "css-selector-tokenizer": "^0.8.0",
+        "css.escape": "^1.5.1"
+      }
+    },
+    "node_modules/@cloudscape-design/theming-build": {
+      "version": "1.0.88",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-build/-/theming-build-1.0.88.tgz",
+      "integrity": "sha512-K3mmZVRMH68U/tcdBt7pEiOrdTjWLU6hG+YAJvU3dTOAwyXTEiqwP8q+lJerT/w7MtbMSwssv0Tp+syFKHfu5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "autoprefixer": "^10.4.8",
+        "glob": "^7.2.3",
+        "jsonschema": "^1.4.1",
+        "loader-utils": "^3.2.1",
+        "lodash": "^4.17.21",
+        "postcss": "^8.4.31",
+        "postcss-discard-empty": "^6.0.0",
+        "postcss-inline-svg": "^6.0.0",
+        "postcss-modules": "^6.0.0",
+        "sass": "^1.77.8",
+        "string-hash": "^1.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@cloudscape-design/theming-runtime": {
+      "version": "1.0.81",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-runtime/-/theming-runtime-1.0.81.tgz",
+      "integrity": "sha512-Md0bPh5wBGUOT9gwCevSmts56U/z0GnfIqtSOXIsqUmXiz2aZ8gMY53agzed4Y0nq+BQ2fvsmRjOr0lfwsp8HA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
@@ -18068,6 +18267,177 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true
+    },
+    "@cloudscape-design/browser-test-tools": {
+      "version": "3.0.96",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/browser-test-tools/-/browser-test-tools-3.0.96.tgz",
+      "integrity": "sha512-/gaRYYRzaCyVds8UNb83u3RZ+r/Hv7PrBzJHwOb14wq7yxLVwLVCmi3Wa3c5qFrxwuseI111Uz237sshFFJuAw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-device-farm": "^3.623.0",
+        "@types/pngjs": "^6.0.4",
+        "@wdio/globals": "^9.7.0",
+        "@wdio/types": "^9.6.3",
+        "get-stream": "^6.0.1",
+        "lodash": "^4.17.21",
+        "p-retry": "^4.6.2",
+        "pixelmatch": "^5.3.0",
+        "pngjs": "^6.0.0",
+        "wait-on": "^8.0.3",
+        "webdriverio": "^9.7.0"
+      }
+    },
+    "@cloudscape-design/build-tools": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/build-tools/-/build-tools-3.0.13.tgz",
+      "integrity": "sha512-kdt0/DtjGPhBJIsJq04+9R+zalPl3OqDmuTUyOuTHvprFGUDNz1Gs0z6cjKqwOVNUpJmybDd1W922e49wjXbew==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^10.0.1"
+      }
+    },
+    "@cloudscape-design/code-view": {
+      "version": "3.0.67",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/code-view/-/code-view-3.0.67.tgz",
+      "integrity": "sha512-jgE5J76hyypePEqg2fQh1hw81IlrHKplOfxveD70qwa4Iia9FWddV9w/+FdTEBgCjZ42aL4zGZFmIIOPGkrQPg==",
+      "dev": true,
+      "requires": {
+        "@cloudscape-design/component-toolkit": "^1.0.0-beta",
+        "ace-code": "^1.32.3",
+        "clsx": "^1.2.1"
+      }
+    },
+    "@cloudscape-design/collection-hooks": {
+      "version": "1.0.73",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/collection-hooks/-/collection-hooks-1.0.73.tgz",
+      "integrity": "sha512-eWj+K2PR4RLSOxDl2fYNPAm+9cqvPr8va5KXthhC/K4tWDSqwFliG6x4vqgdmvifyNJIviD80p6zm8vdk5X27w==",
+      "dev": true,
+      "requires": {}
+    },
+    "@cloudscape-design/component-toolkit": {
+      "version": "1.0.0-beta.109",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.109.tgz",
+      "integrity": "sha512-jSEYlMlLamMLGtot1bWLHKz2GAuPLECLJFaL3FctOM5HR2xT3z5L0J7OckZ+/gNl87V3B7sp4qnaEPBA23rgJQ==",
+      "requires": {
+        "@juggle/resize-observer": "^3.3.1",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@cloudscape-design/components": {
+      "version": "3.0.1027",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.1027.tgz",
+      "integrity": "sha512-y7xYimFI8u7X+2/P8ftP8CRbiIaUsAcZZBZiHZ1HDNzJZpnY+k823emCpVwBKMNivvVmG3Kelj9o5rYjR85tKg==",
+      "dev": true,
+      "requires": {
+        "@cloudscape-design/collection-hooks": "^1.0.0",
+        "@cloudscape-design/component-toolkit": "^1.0.0-beta",
+        "@cloudscape-design/test-utils-core": "^1.0.0",
+        "@cloudscape-design/theming-runtime": "^1.0.0",
+        "@dnd-kit/core": "^6.0.8",
+        "@dnd-kit/sortable": "^7.0.2",
+        "@dnd-kit/utilities": "^3.2.1",
+        "@juggle/resize-observer": "^3.3.1",
+        "ace-builds": "^1.34.0",
+        "balanced-match": "^1.0.2",
+        "clsx": "^1.1.0",
+        "d3-shape": "^1.3.7",
+        "date-fns": "^2.25.0",
+        "intl-messageformat": "^10.3.1",
+        "mnth": "^2.0.0",
+        "react-keyed-flatten-children": "^2.2.1",
+        "react-transition-group": "^4.4.2",
+        "tslib": "^2.4.0",
+        "weekstart": "^1.1.0"
+      },
+      "dependencies": {
+        "react-transition-group": {
+          "version": "4.4.5",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+          "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "dom-helpers": "^5.0.1",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
+          }
+        }
+      }
+    },
+    "@cloudscape-design/design-tokens": {
+      "version": "3.0.59",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/design-tokens/-/design-tokens-3.0.59.tgz",
+      "integrity": "sha512-AYbfj/AT3coKl9UlaMEEJo6BDgcX01GjVCipR+d8IBMh1Imq9gEGmyZdPQjywo4FdRx7ZCqvHdqYCd6QPCvA9g==",
+      "dev": true
+    },
+    "@cloudscape-design/documenter": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/documenter/-/documenter-1.0.48.tgz",
+      "integrity": "sha512-Ppzy16NR8FHJMSlO51MehDVx2DBjSExV9nads2mQiPk0FPrcpcI2jjgVlV0tn8zP3u+Nr080xM5JrqB+44t3cQ==",
+      "dev": true,
+      "requires": {
+        "change-case": "^4.1.1",
+        "micromatch": "^4.0.8",
+        "pathe": "^1.1.2",
+        "typedoc": "~0.19.2"
+      }
+    },
+    "@cloudscape-design/global-styles": {
+      "version": "1.0.44",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.44.tgz",
+      "integrity": "sha512-cQmZ3tsbbMv4QZll0+NzmlUHjmQj0C+9s9nIf1KyV/sdVFGfeFLbV4K4cMmWeu2kOwg1fAE1QkjTI96SpUGM9w==",
+      "dev": true
+    },
+    "@cloudscape-design/test-utils-converter": {
+      "version": "1.0.59",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/test-utils-converter/-/test-utils-converter-1.0.59.tgz",
+      "integrity": "sha512-C1l0ccyrdWBFFdxOK+LuLE/W4q89zYrPYcwU/8RTmoj09SbSzqn3emIJ/SdF+zXl7ZOwfxoRpnE66JNGHUs65Q==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.16.0",
+        "@babel/plugin-syntax-decorators": "^7.16.0",
+        "@babel/plugin-syntax-typescript": "^7.16.0",
+        "glob": "^7.2.0"
+      }
+    },
+    "@cloudscape-design/test-utils-core": {
+      "version": "1.0.59",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/test-utils-core/-/test-utils-core-1.0.59.tgz",
+      "integrity": "sha512-HtNYw0+hXWbOAyR3iA81VVZtHnzFZ9EUp9vShDYVDVSH5EwdlI3O589HjOU6jujojed7T57v3BLM3RK4cTekhQ==",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "^0.8.0",
+        "css.escape": "^1.5.1"
+      }
+    },
+    "@cloudscape-design/theming-build": {
+      "version": "1.0.88",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-build/-/theming-build-1.0.88.tgz",
+      "integrity": "sha512-K3mmZVRMH68U/tcdBt7pEiOrdTjWLU6hG+YAJvU3dTOAwyXTEiqwP8q+lJerT/w7MtbMSwssv0Tp+syFKHfu5g==",
+      "dev": true,
+      "requires": {
+        "autoprefixer": "^10.4.8",
+        "glob": "^7.2.3",
+        "jsonschema": "^1.4.1",
+        "loader-utils": "^3.2.1",
+        "lodash": "^4.17.21",
+        "postcss": "^8.4.31",
+        "postcss-discard-empty": "^6.0.0",
+        "postcss-inline-svg": "^6.0.0",
+        "postcss-modules": "^6.0.0",
+        "sass": "^1.77.8",
+        "string-hash": "^1.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@cloudscape-design/theming-runtime": {
+      "version": "1.0.81",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-runtime/-/theming-runtime-1.0.81.tgz",
+      "integrity": "sha512-Md0bPh5wBGUOT9gwCevSmts56U/z0GnfIqtSOXIsqUmXiz2aZ8gMY53agzed4Y0nq+BQ2fvsmRjOr0lfwsp8HA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
     },
     "@csstools/css-parser-algorithms": {
       "version": "3.0.5",

--- a/pages/03-core/core-dual-axis-chart.page.tsx
+++ b/pages/03-core/core-dual-axis-chart.page.tsx
@@ -1,0 +1,187 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { omit } from "lodash";
+
+import CoreChart from "../../lib/components/internal-do-not-use/core-chart";
+import { dateFormatter } from "../common/formatters";
+import { PageSettingsForm, useChartSettings } from "../common/page-settings";
+import { Page } from "../common/templates";
+import pseudoRandom from "../utils/pseudo-random";
+
+function randomInt(min: number, max: number) {
+  return min + Math.floor(pseudoRandom() * (max - min));
+}
+
+function shuffleArray<T>(array: T[]): void {
+  let currentIndex = array.length;
+  while (currentIndex !== 0) {
+    const randomIndex = Math.floor(Math.random() * currentIndex);
+    currentIndex--;
+    [array[currentIndex], array[randomIndex]] = [array[randomIndex], array[currentIndex]];
+  }
+}
+
+const colors = [
+  "#F15C80",
+  "#2B908F",
+  "#F45B5B",
+  "#91E8E1",
+  "#8085E9",
+  "#E4D354",
+  "#8D4654",
+  "#7798BF",
+  "#AAEEEE",
+  "#FF9655",
+];
+
+const dashStyles: Highcharts.DashStyleValue[] = [
+  "Dash",
+  "DashDot",
+  "Dot",
+  "LongDash",
+  "LongDashDot",
+  "LongDashDotDot",
+  "ShortDash",
+  "ShortDashDot",
+  "ShortDashDotDot",
+  "ShortDot",
+  "Solid",
+];
+
+const baseline = [
+  { x: 1600984800000, y: 58020 },
+  { x: 1600985700000, y: 102402 },
+  { x: 1600986600000, y: 104920 },
+  { x: 1600987500000, y: 94031 },
+  { x: 1600988400000, y: 125021 },
+  { x: 1600989300000, y: 159219 },
+  { x: 1600990200000, y: 193082 },
+  { x: 1600991100000, y: 162592 },
+  { x: 1600992000000, y: 274021 },
+  { x: 1600992900000, y: 264286 },
+  { x: 1600993800000, y: 289210 },
+  { x: 1600994700000, y: 256362 },
+  { x: 1600995600000, y: 257306 },
+  { x: 1600996500000, y: 186776 },
+  { x: 1600997400000, y: 294020 },
+  { x: 1600998300000, y: 385975 },
+  { x: 1600999200000, y: 486039 },
+  { x: 1601000100000, y: 490447 },
+  { x: 1601001000000, y: 361845 },
+  { x: 1601001900000, y: 339058 },
+  { x: 1601002800000, y: 298028 },
+  { x: 1601003400000, y: 255555 },
+  { x: 1601003700000, y: 231902 },
+  { x: 1601004600000, y: 224558 },
+  { x: 1601005500000, y: 253901 },
+  { x: 1601006400000, y: 102839 },
+  { x: 1601007300000, y: 234943 },
+  { x: 1601008200000, y: 204405 },
+  { x: 1601009100000, y: 190391 },
+  { x: 1601010000000, y: 183570 },
+  { x: 1601010900000, y: 162592 },
+  { x: 1601011800000, y: 148910 },
+];
+
+const generatePrimaryAxisData = (letter: string, index: number) => {
+  return baseline.map(({ x, y }) => ({
+    name: `Events ${letter}`,
+    x,
+    y: y === null ? null : y + randomInt(-100000 * ((index % 3) + 1), 100000 * ((index % 3) + 1)),
+  }));
+};
+
+const generateSecondaryAxisData = (letter: string, index: number) => {
+  return baseline.map(({ x, y }) => ({
+    name: `Percentage ${letter}`,
+    x,
+    y: y === null ? null : (y / 10000) * randomInt(3 + (index % 5), 10 + (index % 10)),
+  }));
+};
+
+const primarySeriesData: Record<string, any[]> = {};
+for (let i = 0; i < 10; i++) {
+  const letter = String.fromCharCode(65 + i);
+  primarySeriesData[`data${letter}`] = generatePrimaryAxisData(letter, i);
+}
+
+const secondarySeriesData: Record<string, any[]> = {};
+for (let i = 0; i < 10; i++) {
+  const letter = String.fromCharCode(65 + i);
+  secondarySeriesData[`data${letter}`] = generateSecondaryAxisData(letter, i);
+}
+
+const series: Highcharts.SeriesOptionsType[] = [];
+
+Object.entries(primarySeriesData).forEach(([, data], index) => {
+  series.push({
+    name: data[0].name,
+    type: "line",
+    data: data,
+    yAxis: 0,
+    color: colors[index],
+  });
+});
+
+Object.entries(secondarySeriesData).forEach(([, data], index) => {
+  series.push({
+    name: data[0].name,
+    type: "line",
+    data: data,
+    yAxis: 1,
+    color: colors[index],
+    dashStyle: dashStyles[index % dashStyles.length],
+  });
+});
+
+shuffleArray(series);
+
+export default function () {
+  const { chartProps } = useChartSettings();
+  return (
+    <Page
+      title="Core dual-axis chart demo"
+      subtitle="This page demonstrates the use of the core chart with two Y axes for displaying data with different scales."
+      settings={
+        <PageSettingsForm
+          selectedSettings={[
+            "showLegend",
+            "legendType",
+            "legendPosition",
+            "legendBottomMaxHeight",
+            "showLegendTitle",
+            "showOppositeLegendTitle",
+            "showLegendActions",
+          ]}
+        />
+      }
+    >
+      <CoreChart
+        {...omit(chartProps.cartesian, "ref")}
+        chartHeight={400}
+        ariaLabel="Dual axis line chart"
+        tooltip={{ placement: "outside" }}
+        options={{
+          series: series,
+          xAxis: [
+            {
+              type: "datetime",
+              title: { text: "Time (UTC)" },
+              valueFormatter: dateFormatter,
+            },
+          ],
+          yAxis: [
+            {
+              title: { text: "Events" },
+            },
+            {
+              opposite: true,
+              title: { text: "Percentage (%)" },
+            },
+          ],
+        }}
+      />
+    </Page>
+  );
+}

--- a/pages/common/page-settings.tsx
+++ b/pages/common/page-settings.tsx
@@ -33,7 +33,9 @@ export interface PageSettings {
   tooltipSize: "small" | "medium" | "large";
   showLegend: boolean;
   showLegendTitle: boolean;
+  showOppositeLegendTitle: boolean;
   showLegendActions: boolean;
+  legendType: "single" | "dual";
   legendBottomMaxHeight?: number;
   legendPosition: "bottom" | "side";
   showCustomHeader: boolean;
@@ -59,6 +61,8 @@ const DEFAULT_SETTINGS: PageSettings = {
   tooltipSize: "medium",
   showLegend: true,
   showLegendTitle: false,
+  showOppositeLegendTitle: false,
+  legendType: "single",
   legendPosition: "bottom",
   showLegendActions: false,
   showCustomHeader: false,
@@ -142,10 +146,13 @@ export function useChartSettings<SettingsType extends PageSettings = PageSetting
     // Adding an empty recovery click handler to make the default recovery button appear.
     onRecoveryClick: () => {},
   };
+  console.log(settings.showOppositeLegendTitle);
   const legend = {
     enabled: settings.showLegend,
     title: settings.showLegendTitle ? "Legend title" : undefined,
+    oppositeLegendTitle: settings.showOppositeLegendTitle ? "Opposite Legend title" : undefined,
     actions: settings.showLegendActions ? <Button variant="icon" iconName="search" /> : undefined,
+    type: settings.legendType,
     position: settings.legendPosition,
     bottomMaxHeight: settings.legendBottomMaxHeight,
   };
@@ -342,6 +349,20 @@ export function PageSettingsForm({
                   Show legend
                 </Checkbox>
               );
+            case "legendType":
+              return (
+                <SegmentedControl
+                  label="Legend Type"
+                  selectedId={settings.legendType}
+                  options={[
+                    { text: "Single", id: "single", disabled: !settings.showLegend },
+                    { text: "Dual", id: "dual", disabled: !settings.showLegend },
+                  ]}
+                  onChange={({ detail }) =>
+                    setSettings({ legendType: detail.selectedId as string as "single" | "dual" })
+                  }
+                />
+              );
             case "showLegendTitle":
               return (
                 <Checkbox
@@ -349,6 +370,15 @@ export function PageSettingsForm({
                   onChange={({ detail }) => setSettings({ showLegendTitle: detail.checked })}
                 >
                   Show legend title
+                </Checkbox>
+              );
+            case "showOppositeLegendTitle":
+              return (
+                <Checkbox
+                  checked={settings.showOppositeLegendTitle}
+                  onChange={({ detail }) => setSettings({ showOppositeLegendTitle: detail.checked })}
+                >
+                  Show opposite legend title
                 </Checkbox>
               );
             case "showLegendActions":

--- a/src/core/chart-api/chart-extra-legend.tsx
+++ b/src/core/chart-api/chart-extra-legend.tsx
@@ -81,9 +81,9 @@ export class ChartExtraLegend extends AsyncStore<ReactiveLegendState> {
 
   private initLegend = () => {
     const itemSpecs = getChartLegendItems(this.context.chart());
-    const legendItems = itemSpecs.map(({ id, name, color, markerType, visible }) => {
+    const legendItems = itemSpecs.map(({ id, name, color, markerType, visible, oppositeAxis }) => {
       const marker = this.renderMarker(markerType, color, visible);
-      return { id, name, marker, visible, highlighted: false };
+      return { id, name, marker, visible, oppositeAxis, highlighted: false };
     });
     this.updateLegendItems(legendItems);
   };

--- a/src/core/chart-container.tsx
+++ b/src/core/chart-container.tsx
@@ -29,7 +29,6 @@ interface ChartContainerProps {
   filter?: React.ReactNode;
   navigator?: React.ReactNode;
   legend?: React.ReactNode;
-  legendBottomMaxHeight?: number;
   legendPosition: "bottom" | "side";
   footer?: React.ReactNode;
   fitHeight?: boolean;
@@ -47,7 +46,6 @@ export function ChartContainer({
   footer,
   legend,
   legendPosition,
-  legendBottomMaxHeight,
   navigator,
   fitHeight,
   chartHeight,
@@ -102,9 +100,7 @@ export function ChartContainer({
 
       <div ref={refs.footer} style={chartMinWidth !== undefined ? { minInlineSize: chartMinWidth } : {}}>
         {navigator && <div className={testClasses["chart-navigator"]}>{navigator}</div>}
-        {legend &&
-          legendPosition === "bottom" &&
-          (legendBottomMaxHeight ? <div style={{ maxHeight: `${legendBottomMaxHeight}px` }}>{legend}</div> : legend)}
+        {legendPosition === "bottom" && legend}
         {footer}
       </div>
     </div>

--- a/src/core/chart-core.tsx
+++ b/src/core/chart-core.tsx
@@ -83,6 +83,7 @@ export function InternalCoreChart({
   const rootRef = useRef<HTMLDivElement>(null);
   const mergedRootRef = useMergeRefs(rootRef, __internalRootRef);
   const rootProps = { ref: mergedRootRef, className: rootClassName, ...getDataAttributes(rest) };
+  const legendType = legendOptions?.type ?? "single";
   const legendPosition = legendOptions?.position ?? "bottom";
   const containerProps = {
     fitHeight,
@@ -91,7 +92,6 @@ export function InternalCoreChart({
     chartMinWidth,
     legendPosition,
     verticalAxisTitlePlacement,
-    legendBottomMaxHeight: legendOptions?.bottomMaxHeight,
   };
 
   // Render fallback using the same root and container props as for the chart to ensure consistent
@@ -305,6 +305,7 @@ export function InternalCoreChart({
           context.legendEnabled ? (
             <ChartLegend
               {...legendOptions}
+              type={legendType}
               position={legendPosition}
               api={api}
               i18nStrings={i18nStrings}

--- a/src/core/components/core-legend.tsx
+++ b/src/core/components/core-legend.tsx
@@ -12,14 +12,20 @@ export function ChartLegend({
   api,
   title,
   actions,
+  type,
   position,
   i18nStrings,
+  bottomMaxHeight,
+  oppositeLegendTitle,
   onItemHighlight,
   getLegendTooltipContent,
 }: {
   api: ChartAPI;
   title?: string;
+  oppositeLegendTitle?: string;
+  bottomMaxHeight?: number;
   actions?: React.ReactNode;
+  type: "single" | "dual";
   position: "bottom" | "side";
   i18nStrings?: BaseI18nStrings;
   onItemHighlight?: (detail: CoreChartProps.LegendItemHighlightDetail) => void;
@@ -36,10 +42,13 @@ export function ChartLegend({
   return (
     <ChartLegendComponent
       ariaLabel={ariaLabel}
-      legendTitle={title}
+      type={type}
+      defaultTitle={title}
+      oppositeTitle={oppositeLegendTitle}
       items={legendItems}
       actions={actions}
       position={position}
+      bottomMaxHeight={bottomMaxHeight}
       onItemVisibilityChange={api.onItemVisibilityChange}
       onItemHighlightExit={api.onClearChartItemsHighlight}
       onItemHighlightEnter={(item) => {

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -408,7 +408,9 @@ export namespace CoreChartProps {
 
   export interface LegendOptions extends BaseLegendOptions {
     bottomMaxHeight?: number;
+    type?: "single" | "dual";
     position?: "bottom" | "side";
+    oppositeLegendTitle?: string;
   }
   export type LegendItem = InternalComponentTypes.LegendItem;
   export type LegendTooltipContent = InternalComponentTypes.LegendTooltipContent;

--- a/src/core/styles.scss
+++ b/src/core/styles.scss
@@ -113,7 +113,6 @@ $side-legend-min-inline-size: max(20%, 150px);
 
 .side-legend-container {
   flex: 0;
-  overflow-y: auto;
   max-inline-size: $side-legend-max-inline-size;
   min-inline-size: $side-legend-min-inline-size;
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -15,6 +15,7 @@ export interface LegendItemSpec {
   markerType: ChartSeriesMarkerType;
   color: string;
   visible: boolean;
+  oppositeAxis: boolean;
 }
 
 // The below functions extract unique identifier from series, point, or options. The identifier can be item's ID or name.
@@ -149,6 +150,7 @@ export function getChartLegendItems(chart: Highcharts.Chart): readonly LegendIte
         markerType: getSeriesMarkerType(series),
         color: getSeriesColor(series),
         visible: series.visible,
+        oppositeAxis: series.yAxis.options.opposite ?? false,
       });
     }
   };
@@ -160,6 +162,7 @@ export function getChartLegendItems(chart: Highcharts.Chart): readonly LegendIte
         markerType: getSeriesMarkerType(point.series),
         color: getPointColor(point),
         visible: point.visible,
+        oppositeAxis: false,
       });
     }
   };

--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -22,15 +22,18 @@ import { GetLegendTooltipContentProps, LegendItem, LegendTooltipContent } from "
 import styles from "./styles.css.js";
 import testClasses from "./test-classes/styles.css.js";
 
+const SCROLL_DELAY = 100;
 const TOOLTIP_BLUR_DELAY = 50;
 const HIGHLIGHT_LOST_DELAY = 50;
-const SCROLL_DELAY = 100;
 
 export interface ChartLegendProps {
   items: readonly LegendItem[];
-  legendTitle?: string;
   ariaLabel?: string;
+  defaultTitle?: string;
+  oppositeTitle?: string;
   actions?: React.ReactNode;
+  type: "single" | "dual";
+  bottomMaxHeight?: number;
   position: "bottom" | "side";
   onItemHighlightEnter: (item: LegendItem) => void;
   onItemHighlightExit: () => void;
@@ -39,31 +42,48 @@ export interface ChartLegendProps {
 }
 
 export const ChartLegend = ({
+  type,
   items,
-  legendTitle,
+  defaultTitle,
+  oppositeTitle,
   ariaLabel,
   actions,
   position,
+  bottomMaxHeight,
   onItemVisibilityChange,
   onItemHighlightEnter,
   onItemHighlightExit,
   getTooltipContent,
 }: ChartLegendProps) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const elementsByIndexRef = useRef<Record<number, HTMLElement>>([]);
-  const elementsByIdRef = useRef<Record<string, HTMLElement>>({});
+  // TODO: this is not being assigned to any item
   const tooltipRef = useRef<HTMLElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const tooltipTrack = useRef<null | HTMLElement>(null);
+  const elementsByIdRef = useRef<Record<string, HTMLElement>>({});
   const highlightControl = useMemo(() => new DebouncedCall(), []);
-  const scrollIntoViewControl = useMemo(() => new DebouncedCall(), []);
-  const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const [tooltipItemId, setTooltipItemId] = useState<string | null>(null);
-  const { showTooltip, hideTooltip } = useMemo(() => {
+
+  const tooltipPosition = position === "bottom" ? "bottom" : "left";
+  const tooltipTarget = items.find((item) => item.id === tooltipItemId) ?? null;
+  tooltipTrack.current = tooltipItemId ? elementsByIdRef.current[tooltipItemId] : null;
+  const tooltipContent = tooltipTarget && getTooltipContent({ legendItem: tooltipTarget });
+
+  const { defaultItems, oppositeItems } = useMemo(() => {
+    if (type === "single") {
+      return { defaultItems: items, oppositeItems: [] };
+    }
+    const defaultItems = items.filter((item) => !item.oppositeAxis);
+    const oppositeItems = items.filter((item) => item.oppositeAxis);
+    return { defaultItems, oppositeItems };
+  }, [items, type]);
+
+  const { onShowTooltip, onHideTooltip } = useMemo(() => {
     const control = new DebouncedCall();
     return {
-      showTooltip(itemId: string) {
+      onShowTooltip(itemId: string) {
         control.call(() => setTooltipItemId(itemId));
       },
-      hideTooltip(lock = false) {
+      onHideTooltip(lock = false) {
         control.call(() => setTooltipItemId(null), TOOLTIP_BLUR_DELAY);
         if (lock) {
           control.lock(TOOLTIP_BLUR_DELAY);
@@ -78,7 +98,7 @@ export const ChartLegend = ({
     }
     const onDocumentKeyDown = (event: KeyboardEvent) => {
       if (event.keyCode === KeyCode.escape) {
-        hideTooltip(true);
+        onHideTooltip(true);
         elementsByIdRef.current[tooltipItemId]?.focus();
       }
     };
@@ -86,21 +106,205 @@ export const ChartLegend = ({
     return () => {
       document.removeEventListener("keydown", onDocumentKeyDown, true);
     };
-  }, [items, tooltipItemId, hideTooltip]);
+  }, [items, tooltipItemId, onHideTooltip]);
+
+  const onShowHighlight = (itemId: string) => {
+    const item = items.find((item) => item.id === itemId);
+    if (item?.visible) {
+      highlightControl.cancelPrevious();
+      onItemHighlightEnter(item);
+    }
+  };
+
+  const onToggleItem = (itemId: string) => {
+    const visibleItems = items.filter((i) => i.visible).map((i) => i.id);
+    if (visibleItems.includes(itemId)) {
+      onItemVisibilityChange(visibleItems.filter((visibleItemId) => visibleItemId !== itemId));
+    } else {
+      onItemVisibilityChange([...visibleItems, itemId]);
+    }
+    // Needed for touch devices.
+    onItemHighlightExit();
+  };
+
+  const onSelectItem = (itemId: string) => {
+    const visibleItems = items.filter((i) => i.visible).map((i) => i.id);
+    if (visibleItems.length === 1 && visibleItems[0] === itemId) {
+      onItemVisibilityChange(items.map((i) => i.id));
+    } else {
+      onItemVisibilityChange([itemId]);
+    }
+    // Needed for touch devices.
+    onItemHighlightExit();
+  };
+
+  const legendGroupProps = {
+    actions,
+    tooltipRef,
+    elementsByIdRef,
+    bottomMaxHeight,
+    highlightControl,
+    someHighlighted: items.some((item) => item.highlighted),
+    onHideTooltip,
+    onItemHighlightExit,
+    onSelectItem,
+    onShowHighlight,
+    onShowTooltip,
+    onToggleItem,
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      // TODO: what about this aria-label
+      aria-label={defaultTitle || ariaLabel}
+      className={clsx(testClasses.root, styles.root, {
+        [styles["root-side"]]: position === "side",
+      })}
+    >
+      {position === "bottom" ? (
+        oppositeItems.length === 0 ? (
+          <LegendGroup
+            position={"bottom"}
+            title={defaultTitle}
+            items={defaultItems}
+            ariaLabel={"Chart legend"}
+            {...legendGroupProps}
+          />
+        ) : (
+          <div className={styles["legend-bottom-dual-axis-container"]}>
+            <LegendGroup
+              title={defaultTitle}
+              items={defaultItems}
+              position={"bottom-default"}
+              ariaLabel={"Primary legend"}
+              {...legendGroupProps}
+            />
+            <LegendGroup
+              title={oppositeTitle}
+              items={oppositeItems}
+              position={"bottom-opposite"}
+              ariaLabel={"Opposite legend"}
+              {...legendGroupProps}
+            />
+          </div>
+        )
+      ) : (
+        <>
+          <LegendGroup
+            position={"side"}
+            title={defaultTitle}
+            items={defaultItems}
+            ariaLabel={"Default legend"}
+            scrollableContainerRef={containerRef}
+            {...legendGroupProps}
+          />
+          {oppositeItems.length > 0 && (
+            <>
+              <div className={clsx(styles["legend-divider-side"])} />
+              <LegendGroup
+                position={"side"}
+                title={oppositeTitle}
+                items={oppositeItems}
+                ariaLabel={"Opposite legend"}
+                scrollableContainerRef={containerRef}
+                {...legendGroupProps}
+              />
+            </>
+          )}
+        </>
+      )}
+      {tooltipContent && (
+        <InternalChartTooltip
+          container={null}
+          dismissButton={false}
+          onDismiss={() => {}}
+          onBlur={() => onHideTooltip()}
+          onMouseLeave={() => onHideTooltip()}
+          onMouseEnter={() => onShowTooltip(tooltipTarget.id)}
+          position={tooltipPosition}
+          title={tooltipContent.header}
+          trackKey={tooltipTarget.id}
+          trackRef={tooltipTrack}
+          footer={
+            tooltipContent.footer && (
+              <>
+                <hr aria-hidden={true} />
+                {tooltipContent.footer}
+              </>
+            )
+          }
+        >
+          {tooltipContent.body}
+        </InternalChartTooltip>
+      )}
+    </div>
+  );
+};
+
+interface LegendItemsProps {
+  title?: string;
+  ariaLabel: string;
+  someHighlighted: boolean;
+  bottomMaxHeight?: number;
+  actions?: React.ReactNode;
+  highlightControl: DebouncedCall;
+  items: readonly LegendItem[];
+  tooltipRef: React.RefObject<HTMLElement>;
+  scrollableContainerRef?: React.RefObject<HTMLElement>;
+  position: "bottom" | "bottom-default" | "bottom-opposite" | "side";
+  elementsByIdRef: React.MutableRefObject<Record<string, HTMLElement>>;
+  onItemHighlightExit: () => void;
+  onHideTooltip: (lock?: boolean) => void;
+  onSelectItem: (itemId: string) => void;
+  onToggleItem: (itemId: string) => void;
+  onShowTooltip: (itemId: string) => void;
+  onShowHighlight: (itemId: string) => void;
+}
+
+const LegendGroup = ({
+  title,
+  items,
+  actions,
+  position,
+  ariaLabel,
+  tooltipRef,
+  bottomMaxHeight,
+  someHighlighted,
+  elementsByIdRef,
+  highlightControl,
+  scrollableContainerRef,
+  onToggleItem,
+  onSelectItem,
+  onShowTooltip,
+  onHideTooltip,
+  onShowHighlight,
+  onItemHighlightExit,
+}: LegendItemsProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
   const isMouseInContainer = useRef<boolean>(false);
+  const navigationAPI = useRef<SingleTabStopNavigationAPI>(null);
+  const elementsByIndexRef = useRef<Record<number, HTMLElement>>({});
+
+  const [selectedIndex, setSelectedIndex] = useState<number>(0);
+  const scrollIntoViewControl = useMemo(() => new DebouncedCall(), []);
+
+  useEffect(() => {
+    navigationAPI.current!.updateFocusTarget();
+  });
 
   // Scrolling to the highlighted legend item.
   useEffect(() => {
-    const highlightedIndex = items.findIndex((item) => item.highlighted);
-    if (highlightedIndex === -1) {
+    const highlightedId = items.find((item) => item.highlighted)?.id;
+    if (highlightedId === undefined) {
       return;
     }
     scrollIntoViewControl.call(() => {
       if (isMouseInContainer.current) {
         return;
       }
-      const container = containerRef.current;
-      const element = elementsByIndexRef.current?.[highlightedIndex];
+      const container = scrollableContainerRef?.current ?? containerRef.current;
+      const element = elementsByIdRef.current?.[highlightedId];
       if (!container || !element) {
         return;
       }
@@ -114,35 +318,26 @@ export const ChartLegend = ({
         container.scrollTo({ top, behavior: "smooth" });
       }
     }, SCROLL_DELAY);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [items, scrollIntoViewControl]);
 
-  const showHighlight = (itemId: string) => {
-    const item = items.find((item) => item.id === itemId);
-    if (item?.visible) {
-      highlightControl.cancelPrevious();
-      onItemHighlightEnter(item);
-    }
-  };
   const clearHighlight = () => {
     highlightControl.call(onItemHighlightExit, HIGHLIGHT_LOST_DELAY);
   };
 
-  const navigationAPI = useRef<SingleTabStopNavigationAPI>(null);
-
   function onFocus(index: number, itemId: string) {
     setSelectedIndex(index);
     navigationAPI.current!.updateFocusTarget();
-    showHighlight(itemId);
-    showTooltip(itemId);
+    onShowHighlight(itemId);
+    onShowTooltip(itemId);
   }
 
   function onBlur(event: React.FocusEvent) {
     navigationAPI.current!.updateFocusTarget();
-
     // Hide tooltip and clear highlight unless focus moves inside tooltip;
     if (tooltipRef.current && event.relatedTarget && !tooltipRef.current.contains(event.relatedTarget)) {
       clearHighlight();
-      hideTooltip();
+      onHideTooltip();
     }
   }
 
@@ -177,10 +372,60 @@ export const ChartLegend = ({
     }
   }
 
+  const renderedItems = items.map((item, index) => {
+    const handlers = {
+      onKeyDown,
+      onMouseEnter: () => {
+        onShowHighlight(item.id);
+        onShowTooltip(item.id);
+      },
+      onMouseLeave: () => {
+        clearHighlight();
+        onHideTooltip();
+      },
+      onFocus: () => {
+        onFocus(index, item.id);
+      },
+      onBlur: (event: React.FocusEvent) => {
+        onBlur(event);
+      },
+      onClick: (event: React.MouseEvent<Element, MouseEvent>) => {
+        if (event.metaKey || event.ctrlKey) {
+          onToggleItem(item.id);
+        } else {
+          onSelectItem(item.id);
+        }
+      },
+    };
+    const thisTriggerRef = (elem: null | HTMLElement) => {
+      if (elem) {
+        elementsByIndexRef.current[index] = elem;
+        elementsByIdRef.current[item.id] = elem;
+      } else {
+        delete elementsByIndexRef.current[index];
+        delete elementsByIdRef.current[item.id];
+      }
+    };
+    return (
+      <LegendItemTrigger
+        key={index}
+        {...handlers}
+        itemId={item.id}
+        label={item.name}
+        marker={item.marker}
+        ref={thisTriggerRef}
+        visible={item.visible}
+        isHighlighted={item.highlighted}
+        someHighlighted={someHighlighted}
+      />
+    );
+  });
+
   function getNextFocusTarget(): null | HTMLElement {
     if (containerRef.current) {
+      const highlightedIndex = items.findIndex((item) => item.highlighted);
       const buttons: HTMLButtonElement[] = Array.from(containerRef.current.querySelectorAll(`.${styles.item}`));
-      return buttons[selectedIndex] ?? null;
+      return buttons[highlightedIndex] ?? buttons[0];
     }
     return null;
   }
@@ -190,43 +435,13 @@ export const ChartLegend = ({
     navigationAPI: React.RefObject<{ getFocusTarget: () => HTMLElement | null }>,
   ) {
     const target = navigationAPI.current?.getFocusTarget();
-
     if (target && target.dataset.itemid !== focusableElement.dataset.itemid) {
       target.focus();
     }
   }
 
-  useEffect(() => {
-    navigationAPI.current!.updateFocusTarget();
-  });
-
-  const toggleItem = (itemId: string) => {
-    const visibleItems = items.filter((i) => i.visible).map((i) => i.id);
-    if (visibleItems.includes(itemId)) {
-      onItemVisibilityChange(visibleItems.filter((visibleItemId) => visibleItemId !== itemId));
-    } else {
-      onItemVisibilityChange([...visibleItems, itemId]);
-    }
-    // Needed for touch devices.
-    onItemHighlightExit();
-  };
-
-  const selectItem = (itemId: string) => {
-    const visibleItems = items.filter((i) => i.visible).map((i) => i.id);
-    if (visibleItems.length === 1 && visibleItems[0] === itemId) {
-      onItemVisibilityChange(items.map((i) => i.id));
-    } else {
-      onItemVisibilityChange([itemId]);
-    }
-    // Needed for touch devices.
-    onItemHighlightExit();
-  };
-
-  const tooltipTrack = useRef<null | HTMLElement>(null);
-  const tooltipTarget = items.find((item) => item.id === tooltipItemId) ?? null;
-  tooltipTrack.current = tooltipItemId ? elementsByIdRef.current[tooltipItemId] : null;
-  const tooltipContent = tooltipTarget && getTooltipContent({ legendItem: tooltipTarget });
-  const tooltipPosition = position === "bottom" ? "bottom" : "left";
+  const isDual = position.startsWith("bottom-");
+  const isBottom = position.startsWith("bottom");
 
   return (
     <SingleTabStopNavigationProvider
@@ -236,132 +451,78 @@ export const ChartLegend = ({
       onUnregisterActive={(element: HTMLElement) => onUnregisterActive(element, navigationAPI)}
     >
       <div
-        ref={containerRef}
         role="toolbar"
-        aria-label={legendTitle || ariaLabel}
-        className={clsx(testClasses.root, styles.root, {
-          [styles["root-side"]]: position === "side",
-        })}
+        aria-label={ariaLabel}
         onMouseEnter={() => (isMouseInContainer.current = true)}
         onMouseLeave={() => (isMouseInContainer.current = false)}
+        className={clsx({
+          [styles["legend-dual-group"]]: isDual,
+        })}
       >
-        {legendTitle && (
-          <Box fontWeight="bold" className={testClasses.title}>
-            {legendTitle}
+        {title && (
+          <Box
+            fontWeight="bold"
+            className={testClasses.title}
+            textAlign={position === "bottom-opposite" ? "right" : "left"}
+          >
+            {title}
           </Box>
         )}
-
         <div
           // The list element is not focusable. However, the focus lands on it regardless, when testing in Firefox.
           // Setting the tab index to -1 does fix the problem.
           tabIndex={-1}
+          ref={containerRef}
+          style={{
+            overflow: "auto",
+            maxBlockSize: isBottom && bottomMaxHeight ? `${bottomMaxHeight}px` : undefined,
+          }}
           className={clsx(styles.list, {
-            [styles["list-bottom"]]: position === "bottom",
+            [styles["list-bottom"]]: isBottom,
             [styles["list-side"]]: position === "side",
+            [styles["list-bottom-opposite"]]: position === "bottom-opposite",
           })}
         >
           {actions && (
-            <>
+            <div
+              className={clsx(testClasses.actions, styles.actions, {
+                [styles["actions-bottom"]]: isBottom,
+                [styles["actions-side"]]: position === "side",
+              })}
+            >
+              {actions}
               <div
-                className={clsx(testClasses.actions, styles.actions, {
-                  [styles["actions-bottom"]]: position === "bottom",
-                  [styles["actions-side"]]: position === "side",
+                className={clsx({
+                  [styles["legend-divider-bottom"]]: isBottom,
+                  [styles["legend-divider-side"]]: position === "side",
                 })}
-              >
-                {actions}
-                <div
-                  className={clsx(styles["actions-divider"], {
-                    [styles["actions-divider-bottom"]]: position === "bottom",
-                    [styles["actions-divider-side"]]: position === "side",
-                  })}
-                />
-              </div>
-            </>
+              />
+            </div>
           )}
-          <div
-            className={clsx({
-              [styles["legend-bottom"]]: position === "bottom",
-              [styles["legend-side"]]: position === "side",
-            })}
-          >
-            {items.map((item, index) => {
-              const handlers = {
-                onMouseEnter: () => {
-                  showHighlight(item.id);
-                  showTooltip(item.id);
-                },
-                onMouseLeave: () => {
-                  clearHighlight();
-                  hideTooltip();
-                },
-                onFocus: () => {
-                  onFocus(index, item.id);
-                },
-                onBlur: (event: React.FocusEvent) => {
-                  onBlur(event);
-                },
-                onKeyDown,
-              };
-              const thisTriggerRef = (elem: null | HTMLElement) => {
-                if (elem) {
-                  elementsByIndexRef.current[index] = elem;
-                  elementsByIdRef.current[item.id] = elem;
-                } else {
-                  delete elementsByIndexRef.current[index];
-                  delete elementsByIdRef.current[index];
-                }
-              };
-              return (
-                <LegendItemTrigger
-                  key={index}
-                  {...handlers}
-                  ref={thisTriggerRef}
-                  onClick={(event) => {
-                    if (event.metaKey || event.ctrlKey) {
-                      toggleItem(item.id);
-                    } else {
-                      selectItem(item.id);
-                    }
-                  }}
-                  isHighlighted={item.highlighted}
-                  someHighlighted={items.some((item) => item.highlighted)}
-                  itemId={item.id}
-                  label={item.name}
-                  visible={item.visible}
-                  marker={item.marker}
-                />
-              );
-            })}
-          </div>
+          {renderedItems}
         </div>
-        {tooltipContent && (
-          <InternalChartTooltip
-            trackRef={tooltipTrack}
-            trackKey={tooltipTarget.id}
-            container={null}
-            dismissButton={false}
-            onDismiss={() => {}}
-            position={tooltipPosition}
-            title={tooltipContent.header}
-            onMouseEnter={() => showTooltip(tooltipTarget.id)}
-            onMouseLeave={() => hideTooltip()}
-            onBlur={() => hideTooltip()}
-            footer={
-              tooltipContent.footer && (
-                <>
-                  <hr aria-hidden={true} />
-                  {tooltipContent.footer}
-                </>
-              )
-            }
-          >
-            {tooltipContent.body}
-          </InternalChartTooltip>
-        )}
       </div>
     </SingleTabStopNavigationProvider>
   );
 };
+
+interface LegendItemTriggerProps {
+  isHighlighted?: boolean;
+  itemId: string;
+  label: string;
+  marker?: React.ReactNode;
+  actions?: React.ReactNode;
+  someHighlighted?: boolean;
+  triggerRef?: Ref<HTMLElement>;
+  visible: boolean;
+  onBlur?: (event: React.FocusEvent) => void;
+  onClick: (event: React.MouseEvent) => void;
+  onFocus?: () => void;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLElement>) => void;
+  onMarkerClick?: () => void;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+}
 
 const LegendItemTrigger = forwardRef(
   (
@@ -379,22 +540,7 @@ const LegendItemTrigger = forwardRef(
       onFocus,
       onBlur,
       onKeyDown,
-    }: {
-      isHighlighted?: boolean;
-      someHighlighted?: boolean;
-      itemId: string;
-      label: string;
-      marker?: React.ReactNode;
-      visible: boolean;
-      onClick: (event: React.MouseEvent) => void;
-      onMarkerClick?: () => void;
-      triggerRef?: Ref<HTMLElement>;
-      onMouseEnter?: () => void;
-      onMouseLeave?: () => void;
-      onFocus?: () => void;
-      onBlur?: (event: React.FocusEvent) => void;
-      onKeyDown?: (event: React.KeyboardEvent<HTMLElement>) => void;
-    },
+    }: LegendItemTriggerProps,
     ref: Ref<HTMLButtonElement>,
   ) => {
     const refObject = useRef<HTMLDivElement>(null);
@@ -405,20 +551,20 @@ const LegendItemTrigger = forwardRef(
         data-itemid={itemId}
         aria-pressed={visible}
         aria-current={isHighlighted}
+        onBlur={onBlur}
+        onClick={onClick}
+        onFocus={onFocus}
+        onKeyDown={onKeyDown}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        ref={mergedRef}
+        tabIndex={tabIndex}
         className={clsx(testClasses.item, styles.item, {
           [styles["item--inactive"]]: !visible,
           [testClasses["hidden-item"]]: !visible,
           [styles["item--dimmed"]]: someHighlighted && !isHighlighted,
           [testClasses["dimmed-item"]]: someHighlighted && !isHighlighted,
         })}
-        ref={mergedRef}
-        tabIndex={tabIndex}
-        onClick={onClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        onKeyDown={onKeyDown}
       >
         {marker}
         <span>{label}</span>

--- a/src/internal/components/chart-legend/styles.scss
+++ b/src/internal/components/chart-legend/styles.scss
@@ -12,9 +12,6 @@
   @include styles.styles-reset;
   @include styles.default-text-style;
 
-  overflow: auto;
-  max-height: inherit;
-
   &:focus {
     outline: none;
   }
@@ -22,7 +19,20 @@
 
 .root-side {
   display: flex;
+  overflow-y: auto;
   flex-direction: column;
+  max-block-size: inherit;
+  margin-inline-start: cs.$space-scaled-s;
+}
+
+.legend-dual-group {
+  inline-size: calc(50% - 20px);
+}
+
+.legend-bottom-dual-axis-container {
+  display: flex;
+  inline-size: 100%;
+  justify-content: space-between;
 }
 
 .list {
@@ -37,26 +47,16 @@
 
 .list-bottom {
   flex-wrap: wrap;
-  overflow-y: auto;
-  justify-content: space-between;
-}
-
-.list-side {
-  flex-wrap: nowrap;
-  flex-direction: column;
-}
-
-.legend-bottom {
-  flex: 1;
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: row;
   gap: cs.$space-scaled-xxs cs.$space-static-m;
 }
 
-.legend-side {
-  display: flex;
-  flex-wrap: wrap;
+.list-bottom-opposite {
+  justify-content: flex-end; 
+}
+
+.list-side {
+  flex: 1;
+  flex-wrap: nowrap;
   flex-direction: column;
   gap: cs.$space-scaled-xxs cs.$space-static-m;
 }
@@ -108,16 +108,33 @@
   align-items: flex-start;
 }
 
-.actions-divider-bottom {
+.legend-divider-bottom {
   inline-size: 1px;
   block-size: 80%;
   margin-inline: cs.$space-scaled-xs;
   background: cs.$color-border-divider-default;
 }
 
-.actions-divider-side {
-  inline-size: 80%;
-  block-size: 1px;
-  margin-block-end: cs.$space-scaled-xs;
-  background: cs.$color-border-divider-default;
+.legend-divider-side {
+  // inline-size: 80%;
+  // border-width: 1px;
+  // margin-block-end: cs.$space-scaled-xs;
+  //border-color: cs.$color-border-divider-default;
+
+  //margin-left: auto;
+  //margin-right: auto;
+
+  //display: block;
+  //border-style: inset;
+  //margin-top: 0.5em;
+  //margin-bottom: 0.5em;
+  //border-width: 10px;
+
+    display: block;
+    border: 0;
+    padding: 0;
+    height: 1px;
+    inline-size: 80%;
+    margin-block-end: cs.$scape-scaled-xs;
+    border-top: 1px solid cs.$color-border-divider-default;
 }

--- a/src/internal/components/interfaces.ts
+++ b/src/internal/components/interfaces.ts
@@ -7,6 +7,7 @@ export interface LegendItem {
   marker: React.ReactNode;
   visible: boolean;
   highlighted: boolean;
+  oppositeAxis: boolean;
 }
 
 export type GetLegendTooltipContent = (props: GetLegendTooltipContentProps) => LegendTooltipContent;


### PR DESCRIPTION
### Description

Introduces support for dual-axis chart legends, which properly groups and separates legend items based on which Y-axis they belong to.

Key changes:
- Added `oppositeAxis` property to legend items to track which Y-axis a series belongs to
- Updated the chart legend component to display two separate groups of legend items for dual-axis charts
- Enhanced legend styles to support the new dual-axis layout with appropriate spacing and dividers
- Added a new demo page showing a dual-axis chart with multiple series on each axis

### Things to Improve

<img width="1232" alt="Screenshot 2025-06-27 at 14 06 39" src="https://github.com/user-attachments/assets/c63282d8-12b3-415a-b957-13074b598dfc" />

For bottom legends, I don't really know how to properly integrate the actions components. Looking for suggestions here.

<img width="1183" alt="Screenshot 2025-06-27 at 14 07 22" src="https://github.com/user-attachments/assets/a97a2ff0-86df-44b1-ae09-1a0bd5275d0b" />

Side legends seem mostly fine already. Now that I enabled the Y-axis on the right side I noticed we may want to increase the padding/margin in the legend, since the legend title and the axis title are too close.