### PR TITLE
chore: Fix size behaviour improvements

### DIFF
--- a/pages/common/styles.module.scss
+++ b/pages/common/styles.module.scss
@@ -15,6 +15,7 @@
   border: 1px solid cs.$color-border-status-info;
   border-radius: 4px;
   position: relative;
+  overflow: hidden;
 }
 
 .chart-frame-annotation {

--- a/pages/common/templates.tsx
+++ b/pages/common/templates.tsx
@@ -264,7 +264,7 @@ const ChartFrame = forwardRef(
     ref: React.Ref<HTMLDivElement>,
   ) => {
     return (
-      <div ref={ref} className={styles["chart-frame"]} style={{ height, width, overflow: "hidden" }}>
+      <div ref={ref} className={styles["chart-frame"]} style={{ height, width }}>
         {children}
         <div className={styles["chart-frame-annotation"]}>{annotation}</div>
       </div>

--- a/src/core/__tests__/chart-core-fit-size.test.tsx
+++ b/src/core/__tests__/chart-core-fit-size.test.tsx
@@ -45,7 +45,8 @@ describe("CoreChart: fit-size", () => {
   test("uses explicit chart height", () => {
     const { rerender } = renderChart({ highcharts });
 
-    expect(HighchartsReact).toHaveBeenCalledWith(chartOptionsWithHeight(undefined), expect.anything());
+    // Using default min height of 200px.
+    expect(HighchartsReact).toHaveBeenCalledWith(chartOptionsWithHeight(200), expect.anything());
 
     rerender({ highcharts, options: { chart: { height: "20rem" } } });
 
@@ -110,20 +111,27 @@ describe("CoreChart: fit-size", () => {
       const offset = verticalAxisTitlePlacement === "top" ? 28 : 0;
       const { rerender } = renderChart({ highcharts, fitHeight: true, verticalAxisTitlePlacement });
 
-      await waitFor(() => {
-        expect(HighchartsReact).toHaveBeenCalledWith(chartOptionsWithHeight(80 - offset), expect.anything());
-      });
-
-      rerender({ highcharts, fitHeight: true, chartHeight: 300, verticalAxisTitlePlacement });
-
-      await waitFor(() => {
-        expect(HighchartsReact).toHaveBeenCalledWith(chartOptionsWithHeight(80 - offset), expect.anything());
-      });
-
-      rerender({ highcharts, fitHeight: true, chartHeight: 300, chartMinHeight: 200, verticalAxisTitlePlacement });
-
+      // Uses default min height = 200px.
       await waitFor(() => {
         expect(HighchartsReact).toHaveBeenCalledWith(chartOptionsWithHeight(200 - offset), expect.anything());
+      });
+
+      // Uses measured height when it is bigger than explicitly provided min height.
+      rerender({ highcharts, fitHeight: true, chartMinHeight: 50, verticalAxisTitlePlacement });
+      await waitFor(() => {
+        expect(HighchartsReact).toHaveBeenCalledWith(chartOptionsWithHeight(80 - offset), expect.anything());
+      });
+
+      // Chart height has no effect on charts with fit-height.
+      rerender({ highcharts, fitHeight: true, chartMinHeight: 50, chartHeight: 300, verticalAxisTitlePlacement });
+      await waitFor(() => {
+        expect(HighchartsReact).toHaveBeenCalledWith(chartOptionsWithHeight(80 - offset), expect.anything());
+      });
+
+      // Taking min height which is above the default min height.
+      rerender({ highcharts, fitHeight: true, chartHeight: 300, chartMinHeight: 250, verticalAxisTitlePlacement });
+      await waitFor(() => {
+        expect(HighchartsReact).toHaveBeenCalledWith(chartOptionsWithHeight(250 - offset), expect.anything());
       });
     },
   );

--- a/src/core/chart-container.tsx
+++ b/src/core/chart-container.tsx
@@ -15,6 +15,8 @@ import testClasses from "./test-classes/styles.css.js";
 // Chart container implements the layout for top-level components, including chart plot, legend, and more.
 // It also implements the height- and width overflow behaviors.
 
+const DEFAULT_CHART_MIN_HEIGHT = 200;
+
 interface ChartContainerProps {
   // The header, footer, vertical axis title, and legend are rendered as is, and we measure the height of these components
   // to compute the available height for the chart plot when fitHeight=true. When there is not enough vertical space, the
@@ -51,6 +53,8 @@ export function ChartContainer({
   chartMinHeight,
   chartMinWidth,
 }: ChartContainerProps) {
+  chartMinHeight = chartMinHeight ?? DEFAULT_CHART_MIN_HEIGHT;
+
   // The vertical axis title is rendered above the chart, and is technically not a part of the chart plot.
   // However, we want to include it to the chart's height computations as it does belong to the chart logically.
   // We do so by taking the title's constant height into account, when "top" axis placement is chosen.
@@ -63,47 +67,49 @@ export function ChartContainer({
   const measuredChartHeight = withMinHeight(measures.chart - measures.header - measures.footer);
   const effectiveChartHeight = fitHeight ? measuredChartHeight : withMinHeight(chartHeight);
   return (
-    <div
-      ref={refs.chart}
-      className={clsx({
-        [styles["chart-container-fit-height"]]: fitHeight,
-        [styles["chart-container-min-width"]]: chartMinWidth !== undefined,
-      })}
-    >
-      <div ref={refs.header}>
-        {header}
-        {filter}
-      </div>
+    <div className={styles["chart-container-root"]} style={{ minBlockSize: chartMinHeight }}>
+      <div
+        ref={refs.chart}
+        className={clsx({
+          [styles["chart-container-fit-height"]]: fitHeight,
+          [styles["chart-container-min-width"]]: chartMinWidth !== undefined,
+        })}
+      >
+        <div ref={refs.header}>
+          {header}
+          {filter}
+        </div>
 
-      {legend && legendPosition === "side" ? (
-        <div className={styles["chart-plot-and-legend-wrapper"]}>
+        {legend && legendPosition === "side" ? (
+          <div className={styles["chart-plot-and-legend-wrapper"]}>
+            <div
+              style={{ minInlineSize: chartMinWidth ?? 0 }}
+              className={clsx(styles["chart-plot-wrapper"], testClasses["chart-plot-wrapper"])}
+            >
+              {verticalAxisTitle}
+              {chart(effectiveChartHeight)}
+            </div>
+            <div className={styles["side-legend-container"]} style={{ maxBlockSize: effectiveChartHeight }}>
+              {legend}
+            </div>
+          </div>
+        ) : (
           <div
-            style={{ minInlineSize: chartMinWidth ?? 0 }}
-            className={clsx(styles["chart-plot-wrapper"], testClasses["chart-plot-wrapper"])}
+            style={chartMinWidth !== undefined ? { minInlineSize: chartMinWidth } : {}}
+            className={testClasses["chart-plot-wrapper"]}
           >
             {verticalAxisTitle}
             {chart(effectiveChartHeight)}
           </div>
-          <div className={styles["side-legend-container"]} style={{ maxBlockSize: effectiveChartHeight }}>
-            {legend}
-          </div>
-        </div>
-      ) : (
-        <div
-          style={chartMinWidth !== undefined ? { minInlineSize: chartMinWidth } : {}}
-          className={testClasses["chart-plot-wrapper"]}
-        >
-          {verticalAxisTitle}
-          {chart(effectiveChartHeight)}
-        </div>
-      )}
+        )}
 
-      <div ref={refs.footer} style={chartMinWidth !== undefined ? { minInlineSize: chartMinWidth } : {}}>
-        {navigator && <div className={testClasses["chart-navigator"]}>{navigator}</div>}
-        {legend &&
-          legendPosition === "bottom" &&
-          (legendBottomMaxHeight ? <div style={{ maxHeight: `${legendBottomMaxHeight}px` }}>{legend}</div> : legend)}
-        {footer}
+        <div ref={refs.footer} style={chartMinWidth !== undefined ? { minInlineSize: chartMinWidth } : {}}>
+          {navigator && <div className={testClasses["chart-navigator"]}>{navigator}</div>}
+          {legend &&
+            legendPosition === "bottom" &&
+            (legendBottomMaxHeight ? <div style={{ maxHeight: `${legendBottomMaxHeight}px` }}>{legend}</div> : legend)}
+          {footer}
+        </div>
       </div>
     </div>
   );

--- a/src/core/styles.scss
+++ b/src/core/styles.scss
@@ -89,7 +89,12 @@ $side-legend-min-inline-size: max(20%, 150px);
   gap: cs.$space-static-xxs;
 }
 
+.chart-container-root {
+  block-size: 100%;
+}
+
 .chart-container-fit-height {
+  overflow-x: auto;
   position: absolute;
   inset: 0;
 }


### PR DESCRIPTION
### Description

The PR makes two improvements to the fit-height behaviour of charts:
1. Introducing default min-height. The value of 200px is enough for some simple charts to have a reasonable presentation. Without that, the consumers have to explicitly provide min height as otherwise the chart can shrink below reasonable size.
2. The min height value now affects the block size of the chart. That is a quality of life improvement mostly, as it is still expected that the parent container has a fixed height, so that the absolutely-positioned chart can scale to it. All it does is preventing the chart to render with 0px height when using fit-height inside a flex-size container, which is the case of the website's playground.

### How has this been tested?

* Updated existing unit tests to account for default min height
* Visual regression tests (there is flakiness but no regression)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
