### PR TITLE
chore: Restrict value import from highcharts with eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -103,7 +103,7 @@
           "error",
           {
             "selector": "ImportDeclaration[source.value='highcharts'][importKind='value']",
-            "message": "Use `import type` from 'highcharts' instead of regular import.",
+            "message": "Use `import type Highcharts from 'highcharts'` instead of regular import.",
           },
         ],
       },

--- a/.eslintrc
+++ b/.eslintrc
@@ -96,6 +96,19 @@
   },
   "overrides": [
     {
+      "files": ["src/**"],
+      "excludedFiles": ["src/**/__tests__/**"],
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector": "ImportDeclaration[source.value='highcharts'][importKind='value']",
+            "message": "Use `import type` from 'highcharts' instead of regular import.",
+          },
+        ],
+      },
+    },
+    {
       "files": ["**/__integ__/**", "./test/**"],
       "rules": {
         // useBrowser is not a React hook


### PR DESCRIPTION
### Description

Restricting value import so that the highcharts will not get bundled with the charts code in case dynamic importing is preferred.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
