### PR TITLE
chore: Fix custom footer text in error bars dev page

### DIFF
--- a/pages/01-cartesian-chart/error-bars.page.tsx
+++ b/pages/01-cartesian-chart/error-bars.page.tsx
@@ -213,7 +213,7 @@ function tooltipContent(settings: ThisPageSettings): CartesianChartProps.Tooltip
           items.some((item) => item.errorRanges.length > 0) ? (
             <Box fontSize="body-s">
               {settings.errorsGroupedInFooter
-                ? `Error range: ±${moneyFormatter(items[0].errorRanges[0].high - items[0].errorRanges[0].low)}`
+                ? `Error range: ±${moneyFormatter((items[0].errorRanges[0].high - items[0].errorRanges[0].low) / 2)}`
                 : "*Error range"}
             </Box>
           ) : null,


### PR DESCRIPTION
### Description

If the difference between the lowest and highest value is X, then the measurement is expected to deviate approx. X/2 below and X/2 above, not X below and X above.

### How has this been tested?

On local dev environment:

![Screenshot 2025-07-08 at 14 50 28](https://github.com/user-attachments/assets/1d03cdae-6e50-40d2-b240-38911e30d8e0)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
