### PR TITLE
fix: Fine tune error bar marker color

### DIFF
--- a/src/cartesian-chart/chart-series-cartesian.tsx
+++ b/src/cartesian-chart/chart-series-cartesian.tsx
@@ -3,6 +3,8 @@
 
 import type Highcharts from "highcharts";
 
+import { colorChartsErrorBarMarker } from "@cloudscape-design/design-tokens";
+
 import { PointDataItemType, RangeDataItemOptions } from "../core/interfaces";
 import { createThresholdMetadata, getOptionsId } from "../core/utils";
 import * as Styles from "../internal/chart-styles";
@@ -46,9 +48,10 @@ export const transformCartesianSeries = (
       return { type: "line", id: s.id, name: s.name, data, custom, enableMouseTracking, ...style };
     }
     if (s.type === "errorbar") {
+      const color = s.color ?? colorChartsErrorBarMarker;
       // In Highcharts, the error-bar series graphic color is represented as stem-, and whisker colors.
       // We simplify that, and only expose a single color prop that sets both of those.
-      const colors = s.color ? { stemColor: s.color, whiskerColor: s.color } : {};
+      const colors = { stemColor: color, whiskerColor: color };
       return { ...s, data: s.data as Writeable<RangeDataItemOptions[]>, ...colors };
     }
     return { ...s, data: s.data as Writeable<PointDataItemType[]> };


### PR DESCRIPTION
### Description

Related docs: `3T8mA9G0PI3D`, `JaIkAMOgChPb`.

### How has this been tested?

- Manually in deployed [error bars dev page](https://d21d5uik3ws71m.cloudfront.net/chart-components/f043405f5d143e5574fab6d6383a718f4a56f06f/dev-pages/index.html#/01-cartesian-chart/error-bars) (light and dark mode)
- [Visual regression tests](https://github.com/cloudscape-design/chart-components/actions/runs/16145853854?pr=59) show expected diff

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
