### PR TITLE
fix: Fixes pie chart tooltip placement in Firefox

### DIFF
--- a/src/core/chart-api/chart-extra-tooltip.tsx
+++ b/src/core/chart-api/chart-extra-tooltip.tsx
@@ -125,7 +125,11 @@ export class ChartExtraTooltip extends AsyncStore<ReactiveTooltipState> {
     // We only create target track for pie chart as pie chart does not support groups.
     // It is also expected that only "target" tooltip position is used for pie charts.
     const pointRect = getPieChartTargetPlacement(point);
-    this.targetTrack.rect(this.context.chart().renderer, { ...pointRect, ...this.commonTrackAttrs });
+    this.targetTrack.rect(this.context.chart().renderer, {
+      ...pointRect,
+      ...this.commonTrackAttrs,
+      "data-testid": "XYZ",
+    });
   };
 
   private get commonTrackAttrs() {
@@ -198,7 +202,8 @@ function getPieChartTargetPlacement(point: Highcharts.Point): Rect {
   // Instead, there is a `tooltipPos` tuple, which is not covered by TS.
   // See: https://github.com/highcharts/highcharts/issues/23118.
   if ("tooltipPos" in point && Array.isArray(point.tooltipPos)) {
-    return { x: point.tooltipPos[0], y: point.tooltipPos[1], width: 0, height: 0 };
+    // We use very small but non-zero track size as otherwise it is placed incorrectly in Firefox.
+    return { x: point.tooltipPos[0], y: point.tooltipPos[1], width: 0.1, height: 0.1 };
   }
   // We use the alternative, middle, tooltip placement as a fallback, in case the undocumented "tooltipPos"
   // is no longer available in the point.

--- a/src/core/chart-api/chart-extra-tooltip.tsx
+++ b/src/core/chart-api/chart-extra-tooltip.tsx
@@ -125,11 +125,7 @@ export class ChartExtraTooltip extends AsyncStore<ReactiveTooltipState> {
     // We only create target track for pie chart as pie chart does not support groups.
     // It is also expected that only "target" tooltip position is used for pie charts.
     const pointRect = getPieChartTargetPlacement(point);
-    this.targetTrack.rect(this.context.chart().renderer, {
-      ...pointRect,
-      ...this.commonTrackAttrs,
-      "data-testid": "XYZ",
-    });
+    this.targetTrack.rect(this.context.chart().renderer, { ...pointRect, ...this.commonTrackAttrs });
   };
 
   private get commonTrackAttrs() {


### PR DESCRIPTION
### Description

In Firefox, the tooltip placement in pie chart was incorrect, see:

<img width="1285" height="415" alt="Screenshot 2025-07-17 at 10 17 31" src="https://github.com/user-attachments/assets/8e6a33b5-5853-417f-ae4f-7b92fc0f1a50" />

### How has this been tested?

* Unfortunately, there are no tests to secure this as we lack the tech capability to run integ tests in Firefox atm

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
