### PR TITLE
fix: do not show tooltip on api highlights

### DIFF
--- a/src/core/chart-api/index.tsx
+++ b/src/core/chart-api/index.tsx
@@ -394,10 +394,14 @@ export class ChartAPI {
       // Update tooltip and legend state.
       if (point) {
         this.chartExtraLegend.onHighlightPoint(point);
-        this.chartExtraTooltip.showTooltipOnPoint(point, group, overrideTooltipLock);
+        if (!isApiCall) {
+          this.chartExtraTooltip.showTooltipOnPoint(point, group, overrideTooltipLock);
+        }
       } else {
         this.chartExtraLegend.onHighlightGroup(group);
-        this.chartExtraTooltip.showTooltipOnGroup(group, overrideTooltipLock);
+        if (!isApiCall) {
+          this.chartExtraTooltip.showTooltipOnGroup(group, overrideTooltipLock);
+        }
       }
 
       // Notify the consumer that a highlight action was made.


### PR DESCRIPTION
### Description

Prevents tooltips from automatically showing when programmatically highlighting points. Tested usage through an example in the core-line-chart demo page.