### PR TITLE
feat: add onLegendItemHighlight callback

### DIFF
--- a/src/core/__tests__/chart-core-legend.test.tsx
+++ b/src/core/__tests__/chart-core-legend.test.tsx
@@ -3,10 +3,11 @@
 
 import { act } from "react";
 import highcharts from "highcharts";
+import { vi } from "vitest";
 
 import { KeyCode } from "@cloudscape-design/component-toolkit/internal";
 
-import { createChartWrapper, renderChart } from "./common";
+import { createChartWrapper, hoverLegendItem, renderChart } from "./common";
 import { HighchartsTestHelper } from "./highcharts-utils";
 
 import legendTestClasses from "../../../lib/components/internal/components/chart-legend/test-classes/styles.selectors.js";
@@ -450,5 +451,24 @@ describe("CoreChart: legend", () => {
       expect(wrapper.findLegend()!.findItemTooltip()).not.toBe(null);
       expect(wrapper.findLegend()!.findItemTooltip()!.findHeader()!.getElement().textContent).toBe("P2");
     });
+  });
+
+  test("calls onLegendHover when hovering over a legend item", () => {
+    const onLegendHover = vi.fn();
+    const { wrapper } = renderChart({ highcharts, options: { series }, onLegendHover });
+
+    hoverLegendItem(0, wrapper);
+
+    expect(onLegendHover).toHaveBeenCalledWith(
+      expect.objectContaining({
+        item: expect.objectContaining({
+          id: "Line 1",
+          name: "Line 1",
+          marker: expect.any(Object),
+          visible: expect.any(Boolean),
+          highlighted: expect.any(Boolean),
+        }),
+      }),
+    );
   });
 });

--- a/src/core/__tests__/chart-core-legend.test.tsx
+++ b/src/core/__tests__/chart-core-legend.test.tsx
@@ -462,8 +462,8 @@ describe("CoreChart: legend", () => {
     expect(onLegendHover).toHaveBeenCalledWith(
       expect.objectContaining({
         item: expect.objectContaining({
-          id: "Line 1",
-          name: "Line 1",
+          id: "L1",
+          name: "L1",
           marker: expect.any(Object),
           visible: expect.any(Boolean),
           highlighted: expect.any(Boolean),

--- a/src/core/__tests__/chart-core-legend.test.tsx
+++ b/src/core/__tests__/chart-core-legend.test.tsx
@@ -453,13 +453,13 @@ describe("CoreChart: legend", () => {
     });
   });
 
-  test("calls onLegendHover when hovering over a legend item", () => {
-    const onLegendHover = vi.fn();
-    const { wrapper } = renderChart({ highcharts, options: { series }, onLegendHover });
+  test("calls onLegendItemHighlight when hovering over a legend item", () => {
+    const onLegendItemHighlight = vi.fn();
+    const { wrapper } = renderChart({ highcharts, options: { series }, onLegendItemHighlight });
 
     hoverLegendItem(0, wrapper);
 
-    expect(onLegendHover).toHaveBeenCalledWith(
+    expect(onLegendItemHighlight).toHaveBeenCalledWith(
       expect.objectContaining({
         item: expect.objectContaining({
           id: "L1",

--- a/src/core/__tests__/common.tsx
+++ b/src/core/__tests__/common.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { act, useState } from "react";
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 
 import "@cloudscape-design/components/test-utils/dom";
 import { CoreChartProps } from "../../../lib/components/core/interfaces";
@@ -33,6 +33,7 @@ export function StatefulChart(props: CoreChartProps) {
 }
 
 type TestProps = Partial<CoreChartProps> & {
+  onLegendHover?: () => void;
   i18nProvider?: Record<string, Record<string, string>>;
 };
 
@@ -85,4 +86,9 @@ export function selectLegendItem(index: number, wrapper: BaseChartWrapper = crea
 export function toggleLegendItem(index: number, wrapper: BaseChartWrapper = createChartWrapper()) {
   const modifier = Math.random() > 0.5 ? { metaKey: true } : { ctrlKey: true };
   act(() => wrapper.findLegend()!.findItems()[index].click(modifier));
+}
+export function hoverLegendItem(index: number, wrapper: BaseChartWrapper = createChartWrapper()) {
+  act(() => {
+    fireEvent.mouseOver(wrapper.findLegend()!.findItems()[index].getElement());
+  });
 }

--- a/src/core/__tests__/common.tsx
+++ b/src/core/__tests__/common.tsx
@@ -33,7 +33,7 @@ export function StatefulChart(props: CoreChartProps) {
 }
 
 type TestProps = Partial<CoreChartProps> & {
-  onLegendHover?: () => void;
+  onLegendItemHighlight?: () => void;
   i18nProvider?: Record<string, Record<string, string>>;
 };
 

--- a/src/core/chart-core.tsx
+++ b/src/core/chart-core.tsx
@@ -58,6 +58,7 @@ export function InternalCoreChart({
   filter,
   keyboardNavigation = true,
   onHighlight,
+  onLegendHover,
   onClearHighlight,
   onVisibleItemsChange,
   visibleItems,
@@ -307,6 +308,7 @@ export function InternalCoreChart({
               position={legendPosition}
               api={api}
               i18nStrings={i18nStrings}
+              onItemHover={onLegendHover}
               getLegendTooltipContent={rest.getLegendTooltipContent}
             />
           ) : null

--- a/src/core/chart-core.tsx
+++ b/src/core/chart-core.tsx
@@ -58,7 +58,7 @@ export function InternalCoreChart({
   filter,
   keyboardNavigation = true,
   onHighlight,
-  onLegendHover,
+  onLegendItemHighlight,
   onClearHighlight,
   onVisibleItemsChange,
   visibleItems,
@@ -308,7 +308,7 @@ export function InternalCoreChart({
               position={legendPosition}
               api={api}
               i18nStrings={i18nStrings}
-              onItemHover={onLegendHover}
+              onItemHighlight={onLegendItemHighlight}
               getLegendTooltipContent={rest.getLegendTooltipContent}
             />
           ) : null

--- a/src/core/components/core-legend.tsx
+++ b/src/core/components/core-legend.tsx
@@ -14,6 +14,7 @@ export function ChartLegend({
   actions,
   position,
   i18nStrings,
+  onItemHover,
   getLegendTooltipContent,
 }: {
   api: ChartAPI;
@@ -21,6 +22,7 @@ export function ChartLegend({
   actions?: React.ReactNode;
   position: "bottom" | "side";
   i18nStrings?: BaseI18nStrings;
+  onItemHover?: (detail: CoreChartProps.LegendHoverDetail) => void;
   getLegendTooltipContent?: CoreChartProps.GetLegendTooltipContent;
 }) {
   const i18n = useInternalI18n("[charts]");
@@ -39,8 +41,11 @@ export function ChartLegend({
       actions={actions}
       position={position}
       onItemVisibilityChange={api.onItemVisibilityChange}
-      onItemHighlightEnter={(itemId) => api.onHighlightChartItems([itemId])}
       onItemHighlightExit={api.onClearChartItemsHighlight}
+      onItemHighlightEnter={(item) => {
+        api.onHighlightChartItems([item.id]);
+        onItemHover?.({ item });
+      }}
       getTooltipContent={(props) => {
         if (isChartTooltipPinned) {
           return null;

--- a/src/core/components/core-legend.tsx
+++ b/src/core/components/core-legend.tsx
@@ -14,7 +14,7 @@ export function ChartLegend({
   actions,
   position,
   i18nStrings,
-  onItemHover,
+  onItemHighlight,
   getLegendTooltipContent,
 }: {
   api: ChartAPI;
@@ -22,7 +22,7 @@ export function ChartLegend({
   actions?: React.ReactNode;
   position: "bottom" | "side";
   i18nStrings?: BaseI18nStrings;
-  onItemHover?: (detail: CoreChartProps.LegendHoverDetail) => void;
+  onItemHighlight?: (detail: CoreChartProps.LegendHoverDetail) => void;
   getLegendTooltipContent?: CoreChartProps.GetLegendTooltipContent;
 }) {
   const i18n = useInternalI18n("[charts]");
@@ -44,7 +44,7 @@ export function ChartLegend({
       onItemHighlightExit={api.onClearChartItemsHighlight}
       onItemHighlightEnter={(item) => {
         api.onHighlightChartItems([item.id]);
-        onItemHover?.({ item });
+        onItemHighlight?.({ item });
       }}
       getTooltipContent={(props) => {
         if (isChartTooltipPinned) {

--- a/src/core/components/core-legend.tsx
+++ b/src/core/components/core-legend.tsx
@@ -22,7 +22,7 @@ export function ChartLegend({
   actions?: React.ReactNode;
   position: "bottom" | "side";
   i18nStrings?: BaseI18nStrings;
-  onItemHighlight?: (detail: CoreChartProps.LegendHoverDetail) => void;
+  onItemHighlight?: (detail: CoreChartProps.LegendItemHighlightDetail) => void;
   getLegendTooltipContent?: CoreChartProps.GetLegendTooltipContent;
 }) {
   const i18n = useInternalI18n("[charts]");

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -342,6 +342,10 @@ export interface CoreChartProps
    */
   visibleItems?: readonly string[];
   /**
+   * Called when the user hovers over a legend item.
+   */
+  onLegendHover?: (detail: CoreChartProps.LegendHoverDetail) => void;
+  /**
    * Called when series/points visibility changes due to user interaction with legend or filter.
    */
   onVisibleItemsChange?: (detail: CoreChartProps.VisibleItemsChangeDetail) => void;
@@ -440,6 +444,9 @@ export namespace CoreChartProps {
     items: TooltipContentItem[];
   }
 
+  export interface LegendHoverDetail {
+    item: LegendItem;
+  }
   export interface VisibleItemsChangeDetail {
     items: readonly LegendItem[];
     isApiCall: boolean;

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -344,7 +344,7 @@ export interface CoreChartProps
   /**
    * Called when a legend item is highlighted.
    */
-  onLegendItemHighlight?: (detail: CoreChartProps.LegendHoverDetail) => void;
+  onLegendItemHighlight?: (detail: CoreChartProps.LegendItemHighlightDetail) => void;
   /**
    * Called when series/points visibility changes due to user interaction with legend or filter.
    */
@@ -444,7 +444,7 @@ export namespace CoreChartProps {
     items: TooltipContentItem[];
   }
 
-  export interface LegendHoverDetail {
+  export interface LegendItemHighlightDetail {
     item: LegendItem;
   }
   export interface VisibleItemsChangeDetail {

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -342,9 +342,9 @@ export interface CoreChartProps
    */
   visibleItems?: readonly string[];
   /**
-   * Called when the user hovers over a legend item.
+   * Called when a legend item is highlighted.
    */
-  onLegendHover?: (detail: CoreChartProps.LegendHoverDetail) => void;
+  onLegendItemHighlight?: (detail: CoreChartProps.LegendHoverDetail) => void;
   /**
    * Called when series/points visibility changes due to user interaction with legend or filter.
    */

--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -32,7 +32,7 @@ export interface ChartLegendProps {
   ariaLabel?: string;
   actions?: React.ReactNode;
   position: "bottom" | "side";
-  onItemHighlightEnter: (itemId: string) => void;
+  onItemHighlightEnter: (item: LegendItem) => void;
   onItemHighlightExit: () => void;
   onItemVisibilityChange: (hiddenItems: string[]) => void;
   getTooltipContent: (props: GetLegendTooltipContentProps) => null | LegendTooltipContent;
@@ -120,7 +120,7 @@ export const ChartLegend = ({
     const item = items.find((item) => item.id === itemId);
     if (item?.visible) {
       highlightControl.cancelPrevious();
-      onItemHighlightEnter(itemId);
+      onItemHighlightEnter(item);
     }
   };
   const clearHighlight = () => {


### PR DESCRIPTION
### Description

Adds a `onLegendHover` callback in the core chart component.

### How has this been tested?

Tested manually. Updates unit tests.