### PR TITLE
feat: Adds details renderer to core tooltip API

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -883,7 +883,7 @@ Supported series types:
           {
             "name": "details",
             "optional": true,
-            "type": "((props: TooltipSlotRenderProps) => ReadonlyArray<PieChartProps.TooltipDetail>)",
+            "type": "((props: TooltipSlotRenderProps) => ReadonlyArray<BaseTooltipDetail>)",
           },
           {
             "name": "enabled",

--- a/src/core/components/core-tooltip.tsx
+++ b/src/core/components/core-tooltip.tsx
@@ -215,11 +215,15 @@ function getTooltipContentPie(
         </Box>
       </div>
     ),
-    body: renderers.body?.(tooltipDetails) ?? (
-      // We expect all pie chart segments to have defined y values. We use y=0 as fallback
-      // because the property is optional in Highcharts types.
-      <ChartSeriesDetails details={[{ key: point.series.name, value: point.y ?? 0 }]} />
-    ),
+    body:
+      renderers.body?.(tooltipDetails) ??
+      (renderers.details ? (
+        <ChartSeriesDetails details={renderers.details({ point })} compactList={true} />
+      ) : (
+        // We expect all pie chart segments to have defined y values. We use y=0 as fallback
+        // because the property is optional in Highcharts types.
+        <ChartSeriesDetails details={[{ key: point.series.name, value: point.y ?? 0 }]} />
+      )),
     footer: renderers.footer?.(tooltipDetails),
   };
 }

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -428,6 +428,7 @@ export namespace CoreChartProps {
   }
   export interface TooltipContentRenderer {
     point?: (props: TooltipPointProps) => TooltipPointFormatted;
+    details?: (props: TooltipDetailsProps) => readonly TooltipDetail[];
     header?: (props: TooltipSlotProps) => React.ReactNode;
     body?: (props: TooltipSlotProps) => React.ReactNode;
     footer?: (props: TooltipSlotProps) => React.ReactNode;
@@ -443,6 +444,15 @@ export namespace CoreChartProps {
   export interface TooltipSlotProps {
     x: number;
     items: TooltipContentItem[];
+  }
+
+  export interface TooltipDetailsProps {
+    point: Highcharts.Point;
+  }
+
+  export interface TooltipDetail {
+    key: React.ReactNode;
+    value: React.ReactNode;
   }
 
   export interface LegendItemHighlightDetail {

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -108,6 +108,11 @@ export interface BaseNoDataOptions {
   onRecoveryClick?: NonCancelableEventHandler;
 }
 
+export interface BaseTooltipDetail {
+  key: React.ReactNode;
+  value: React.ReactNode;
+}
+
 export interface BaseI18nStrings {
   loadingText?: string;
   errorText?: string;
@@ -450,10 +455,7 @@ export namespace CoreChartProps {
     point: Highcharts.Point;
   }
 
-  export interface TooltipDetail {
-    key: React.ReactNode;
-    value: React.ReactNode;
-  }
+  export type TooltipDetail = BaseTooltipDetail;
 
   export interface LegendItemHighlightDetail {
     item: LegendItem;

--- a/src/pie-chart/interfaces.ts
+++ b/src/pie-chart/interfaces.ts
@@ -105,10 +105,7 @@ export namespace PieChartProps {
     totalValue: number;
   }
 
-  export interface TooltipDetail {
-    key: React.ReactNode;
-    value: React.ReactNode;
-  }
+  export type TooltipDetail = CoreTypes.BaseTooltipDetail;
 
   export type SegmentTitleRenderProps = SegmentDescriptionRenderProps;
   export interface SegmentDescriptionRenderProps {


### PR DESCRIPTION
### Description

The change moves the pie chart tooltip details renderer from the public pie-chart to core.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
