### PR TITLE
fix: Sanitize URL in prepare-package-lock script

### DIFF
--- a/scripts/prepare-package-lock.js
+++ b/scripts/prepare-package-lock.js
@@ -23,7 +23,10 @@ function unlock(packages) {
 
     if (dependencyName.includes("@cloudscape-design/")) {
       delete packages[dependencyName];
-    } else if (dependency.resolved && dependency.resolved.includes("codeartifact.us-west-2.amazonaws.com")) {
+    } else if (
+      dependency.resolved &&
+      new URL(dependency.resolved).host.endsWith("codeartifact.us-west-2.amazonaws.com")
+    ) {
       throw Error(
         "package-lock.json file contains a reference to CodeArtifact. Use regular npm to update the packages.",
       );


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
