### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -16,6 +16,8 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.event.ref != 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
@@ -46,6 +48,8 @@ jobs:
   update:
     name: Update Snapshots
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: github.event.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/cloudscape-design/chart-components/security/code-scanning/3](https://github.com/cloudscape-design/chart-components/security/code-scanning/3)

To fix the problem, add an explicit `permissions` block to the workflow file. This block should specify the minimal permissions required for each job. For example:

- For the `test` job, it likely only requires `contents: read` since it primarily checks out the repository, installs dependencies, runs tests, and downloads/upload artifacts.
- For the `update` job, it may need `contents: write` to update snapshots.

The `permissions` block should be added at the job level to ensure different permissions for `test` and `update` jobs. This ensures each job only has access to what it needs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
