### PR TITLE
chore: Fixes iframe screenshot tests

### DIFF
--- a/pages/06-visual-tests/in-iframe.page.tsx
+++ b/pages/06-visual-tests/in-iframe.page.tsx
@@ -10,11 +10,11 @@ import { IframeWrapper } from "../utils/iframe-wrapper";
 
 export default function () {
   return (
-    <IframeWrapper
-      AppComponent={() => {
-        const { chartProps } = useChartSettings();
-        return (
-          <Page title="Chart inside iframe visual regression page">
+    <Page title="Chart inside iframe visual regression page">
+      <IframeWrapper
+        AppComponent={() => {
+          const { chartProps } = useChartSettings();
+          return (
             <CoreChart
               {...omit(chartProps.pie, "ref")}
               ariaLabel="Pie chart"
@@ -40,9 +40,9 @@ export default function () {
                 }, 0);
               }}
             />
-          </Page>
-        );
-      }}
-    />
+          );
+        }}
+      />
+    </Page>
   );
 }


### PR DESCRIPTION
### Description

Without this fix the screenshot tests are not uploaded because the workflow fails with `cannot find element "main"` error in the iframe test page.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
