### PR TITLE
chore: avoid re-rendering tooltips on each cursor pixel change over charts

### DIFF
--- a/src/core/__tests__/chart-core-tooltip.test.tsx
+++ b/src/core/__tests__/chart-core-tooltip.test.tsx
@@ -316,6 +316,45 @@ describe("CoreChart: tooltip", () => {
     }
   });
 
+  test("only re-renders when group has changed", () => {
+    const getTooltipContentMock = vi.fn(() => ({
+      header: () => "Tooltip title",
+      body: () => "Tooltip body",
+      footer: () => "Tooltip footer",
+    }));
+    renderChart({
+      highcharts,
+      options: {
+        series: lineSeries,
+        chart: {
+          events: {
+            load() {
+              this.plotTop = 0;
+              this.plotLeft = 0;
+              this.plotWidth = 100;
+              this.plotHeight = 100;
+            },
+          },
+        },
+      },
+      getTooltipContent: getTooltipContentMock,
+    });
+
+    act(() => {
+      hc.getChart().container.dispatchEvent(createMouseMoveEvent({ pageX: 1, pageY: 0 }));
+    });
+
+    act(() => {
+      hc.getChart().container.dispatchEvent(createMouseMoveEvent({ pageX: 1, pageY: 2 }));
+    });
+
+    act(() => {
+      hc.getChart().container.dispatchEvent(createMouseMoveEvent({ pageX: 1, pageY: 4 }));
+    });
+
+    expect(getTooltipContentMock).toHaveBeenCalledTimes(2);
+  });
+
   test("renders highlight markers", async () => {
     const { wrapper } = renderChart({
       highcharts,

--- a/src/core/chart-api/chart-extra-tooltip.tsx
+++ b/src/core/chart-api/chart-extra-tooltip.tsx
@@ -10,7 +10,7 @@ import * as Styles from "../../internal/chart-styles";
 import { renderMarker } from "../../internal/components/series-marker/render-marker";
 import AsyncStore from "../../internal/utils/async-store";
 import { SVGRendererPool, SVGRendererSingle } from "../../internal/utils/renderer-utils";
-import { DebouncedCall } from "../../internal/utils/utils";
+import { DebouncedCall, isEqualArrays } from "../../internal/utils/utils";
 import { Rect } from "../interfaces";
 import { getGroupRect, getPointRect, isXThreshold } from "../utils";
 import { ChartExtraContext } from "./chart-extra-context";
@@ -78,7 +78,7 @@ export class ChartExtraTooltip extends AsyncStore<ReactiveTooltipState> {
 
   public showTooltipOnGroup(group: readonly Highcharts.Point[], ignoreLock = false) {
     if (!this.tooltipLock || ignoreLock) {
-      this.set(() => ({ visible: true, pinned: false, point: null, group }));
+      this.setGroupIfDifferent(group);
       this.onRenderTooltip({ point: null, group });
     }
   }
@@ -95,6 +95,20 @@ export class ChartExtraTooltip extends AsyncStore<ReactiveTooltipState> {
     if (this.context.settings.tooltipEnabled) {
       this.set((prev) => ({ ...prev, visible: true, pinned: true }));
     }
+  }
+
+  // Avoid re-rendering the tooltip on every cursor position change when hovering over the graph.
+  // Just re-render when the groups are different.
+  private setGroupIfDifferent(group: readonly Highcharts.Point[]) {
+    function isGroupEqual(a: Highcharts.Point, b: Highcharts.Point) {
+      return a?.x === b?.x && a?.y === b?.y && a?.series?.type === b?.series?.type;
+    }
+
+    this.set((prev) => {
+      return isEqualArrays(prev.group, group, isGroupEqual)
+        ? prev
+        : { visible: true, pinned: false, point: null, group };
+    });
   }
 
   private onRenderTooltip = (props: { point: null | Highcharts.Point; group: readonly Highcharts.Point[] }) => {

--- a/src/core/chart-api/chart-extra-tooltip.tsx
+++ b/src/core/chart-api/chart-extra-tooltip.tsx
@@ -12,7 +12,7 @@ import AsyncStore from "../../internal/utils/async-store";
 import { SVGRendererPool, SVGRendererSingle } from "../../internal/utils/renderer-utils";
 import { DebouncedCall, isEqualArrays } from "../../internal/utils/utils";
 import { Rect } from "../interfaces";
-import { getGroupRect, getPointRect, isXThreshold } from "../utils";
+import { getGroupRect, getPointRect, getSeriesId, isXThreshold } from "../utils";
 import { ChartExtraContext } from "./chart-extra-context";
 
 import testClasses from "../test-classes/styles.css.js";
@@ -101,7 +101,7 @@ export class ChartExtraTooltip extends AsyncStore<ReactiveTooltipState> {
   // Just re-render when the groups are different.
   private setGroupIfDifferent(group: readonly Highcharts.Point[]) {
     function isGroupEqual(a: Highcharts.Point, b: Highcharts.Point) {
-      return a?.x === b?.x && a?.y === b?.y && a?.series?.type === b?.series?.type;
+      return a?.x === b?.x && a?.y === b?.y && getSeriesId(a?.series) === getSeriesId(b?.series);
     }
 
     this.set((prev) => {


### PR DESCRIPTION
### Description

Significantly reduces the amount of re-renders on data point tooltips by implementing group deep equality check -- groups change depending on the cursor position on the chart and the proximity of the datapoints to the cursor, at the moment it is not necessary to re-render the tooltip when we know we are still on the same group domain. 

### Using react dev tools to analyze the cadence of the render events

#### Before
![tooltip-render-issue](https://github.com/user-attachments/assets/34e33a9f-89b4-4529-b08d-41586cf1f493)

#### After
![tooltip-render-fix](https://github.com/user-attachments/assets/a2988740-1e18-4596-9bde-c453fc1a8ded)

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_

</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
