### PR TITLE
fix: handle text overflow for long legend item labels

### DIFF
--- a/pages/01-cartesian-chart/chart-size.page.tsx
+++ b/pages/01-cartesian-chart/chart-size.page.tsx
@@ -11,7 +11,7 @@ import pseudoRandom from "../utils/pseudo-random";
 const splineSeries: CartesianChartProps.SeriesOptions[] = [
   {
     type: "spline",
-    name: "Demo spline fifty",
+    name: "Demo spline fifty with a really really really long label name",
     data: range(0, 100).map((i) => ({ x: i * 10, y: Math.floor((pseudoRandom() + i / 25) * 50) })),
   },
   {

--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -421,7 +421,7 @@ const LegendItemTrigger = forwardRef(
         onKeyDown={onKeyDown}
       >
         {marker}
-        <span>{label}</span>
+        <span className={styles["item-label"]}>{label}</span>
       </button>
     );
   },

--- a/src/internal/components/chart-legend/styles.scss
+++ b/src/internal/components/chart-legend/styles.scss
@@ -73,6 +73,7 @@
   background-color: transparent;
   cursor: pointer;
   opacity: 1;
+  max-width: 100%;
 
   &:focus {
     outline: none;
@@ -92,6 +93,11 @@
   &.item--dimmed {
     opacity: 0.35;
   }
+}
+
+.item-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .actions {

--- a/src/internal/components/chart-legend/styles.scss
+++ b/src/internal/components/chart-legend/styles.scss
@@ -97,7 +97,10 @@
 
 .item-label {
   overflow: hidden;
-  text-overflow: ellipsis;
+  display: -webkit-box;
+  line-clamp: 3;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 }
 
 .actions {


### PR DESCRIPTION
### Description

Adds proper handling of text overflow for long legend item labels.

#### Before

<img width="353" height="213" alt="Screenshot 2025-08-08 at 09 54 47" src="https://github.com/user-attachments/assets/abb6d514-493d-458d-b6b6-d666b48b8db3" />

#### After

<img width="353" height="219" alt="Screenshot 2025-08-08 at 09 54 23" src="https://github.com/user-attachments/assets/ea43064e-04e7-4fc8-b763-7e120a485ead" />