### PR TITLE
fix: chart sometimes crash on zoom re-render

### DIFF
--- a/src/core/chart-api/chart-extra-context.tsx
+++ b/src/core/chart-api/chart-extra-context.tsx
@@ -102,7 +102,7 @@ function computeDerivedState(chart: Highcharts.Chart): ChartExtraContext.Derived
       for (const d of s.data) {
         // Points with y=null represent the absence of value, there is no need to include them and those
         // should have no impact on computed rects or navigation.
-        if (d.visible && d.y !== null) {
+        if (d?.visible && d.y !== null) {
           seriesX.add(d.x);
           allXSet.add(d.x);
           addPoint(d);

--- a/src/core/chart-api/chart-extra-context.tsx
+++ b/src/core/chart-api/chart-extra-context.tsx
@@ -102,7 +102,10 @@ function computeDerivedState(chart: Highcharts.Chart): ChartExtraContext.Derived
       for (const d of s.data) {
         // Points with y=null represent the absence of value, there is no need to include them and those
         // should have no impact on computed rects or navigation.
-        if (d?.visible && d.y !== null) {
+
+        // Although "d" can't be undefined according to Highcharts API, it does become undefined for chart containing more datapoints
+        // than the cropThreshold for that series (specific cases of re-rendering the chart with updated options listening to setExteme updates)
+        if (d && d.visible && d.y !== null) {
           seriesX.add(d.x);
           allXSet.add(d.x);
           addPoint(d);


### PR DESCRIPTION
### Description

Some of the charts with large amount of datapoints crashes in CW charts using core-chart

The issue does not happen on render but only when zoomed and the zoom causes the re-render (CloudWatch has additional logic to update the chart on zoom).

Tries reproducing within CoreChart directly but it would require setting up some kind of event sync logic and updating charts extremes.

<img width="1360" height="522" alt="Screenshot 2025-08-08 at 14 13 46" src="https://github.com/user-attachments/assets/90183c6d-f69b-4b19-80a4-771b29e7cb3e" />

<img width="521" height="176" alt="Screenshot 2025-08-08 at 14 14 07" src="https://github.com/user-attachments/assets/4935588d-0186-4697-b86b-d9a94c5f9151" />

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
