### PR TITLE
feat: use better formatting for small values

### DIFF
--- a/pages/common/formatters.ts
+++ b/pages/common/formatters.ts
@@ -21,13 +21,32 @@ export function numberFormatter(value: null | number) {
   if (value === null) {
     return "";
   }
-  return Math.abs(value) >= 1e9
-    ? (value / 1e9).toFixed(1).replace(/\.0$/, "") + "G"
-    : Math.abs(value) >= 1e6
-      ? (value / 1e6).toFixed(1).replace(/\.0$/, "") + "M"
-      : Math.abs(value) >= 1e3
-        ? (value / 1e3).toFixed(1).replace(/\.0$/, "") + "K"
-        : value.toFixed(2);
+
+  const format = (num: number) => parseFloat(num.toFixed(2)).toString(); // trims unnecessary decimals
+
+  const absValue = Math.abs(value);
+
+  if (absValue === 0) {
+    return "0";
+  }
+
+  if (absValue < 0.01) {
+    return value.toExponential(0);
+  }
+
+  if (absValue >= 1e9) {
+    return format(value / 1e9) + "G";
+  }
+
+  if (absValue >= 1e6) {
+    return format(value / 1e6) + "M";
+  }
+
+  if (absValue >= 1e3) {
+    return format(value / 1e3) + "K";
+  }
+
+  return format(value);
 }
 
 export function moneyFormatter(value: null | number) {

--- a/src/core/__tests__/chart-core-axes.test.tsx
+++ b/src/core/__tests__/chart-core-axes.test.tsx
@@ -126,6 +126,7 @@ describe("CoreChart: axes", () => {
   test("uses default numeric axes formatters for integer values", () => {
     renderChart({ highcharts, options: { series, xAxis: { title: { text: "X" } }, yAxis: { title: { text: "Y" } } } });
     getAxisOptionsFormatters().forEach((formatter) => {
+      expect(formatter.call(mockAxisContext({ value: 0 }))).toBe("0");
       expect(formatter.call(mockAxisContext({ value: 1 }))).toBe("1");
       expect(formatter.call(mockAxisContext({ value: 1_000 }))).toBe("1K");
       expect(formatter.call(mockAxisContext({ value: 1_000_000 }))).toBe("1M");
@@ -138,6 +139,8 @@ describe("CoreChart: axes", () => {
     getAxisOptionsFormatters().forEach((formatter) => {
       expect(formatter.call(mockAxisContext({ value: 2.0 }))).toBe("2");
       expect(formatter.call(mockAxisContext({ value: 2.03 }))).toBe("2.03");
+      expect(formatter.call(mockAxisContext({ value: 0.03 }))).toBe("0.03");
+      expect(formatter.call(mockAxisContext({ value: 0.003 }))).toBe("3e-3");
     });
   });
 

--- a/src/core/formatters.tsx
+++ b/src/core/formatters.tsx
@@ -104,11 +104,28 @@ function secondFormatter(value: number) {
 
 function numberFormatter(value: number): string {
   const format = (num: number) => parseFloat(num.toFixed(2)).toString(); // trims unnecessary decimals
-  return Math.abs(value) >= 1e9
-    ? format(value / 1e9) + "G"
-    : Math.abs(value) >= 1e6
-      ? format(value / 1e6) + "M"
-      : Math.abs(value) >= 1e3
-        ? format(value / 1e3) + "K"
-        : format(value);
+
+  const absValue = Math.abs(value);
+
+  if (absValue === 0) {
+    return "0";
+  }
+
+  if (absValue < 0.01) {
+    return value.toExponential(0);
+  }
+
+  if (absValue >= 1e9) {
+    return format(value / 1e9) + "G";
+  }
+
+  if (absValue >= 1e6) {
+    return format(value / 1e6) + "M";
+  }
+
+  if (absValue >= 1e3) {
+    return format(value / 1e3) + "K";
+  }
+
+  return format(value);
 }


### PR DESCRIPTION
### Description

This change updates the number formatting for axis labels to better represent small values.

At the moment, for small values (<0.01) we’re losing the precision entirely in the y axis ticks. This change fixes that by using exponential notation for the small numbers. This gives the small number better formatting meanwhile keeping the amount of space consumed the same. It also updates the default formatter used in the examples ("pages") to be the same.

Related links, issue #, if available: n/a

### How has this been tested?

* Manual Test
* Unit tests

<img width="733" height="464" alt="Screenshot 2025-08-12 at 5 45 54 p m" src="https://github.com/user-attachments/assets/821357c1-3066-4d35-8918-1fb3e7e5c363" />


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
