### PR TITLE
fix: handle text overflow for long legend item labels

### DIFF
--- a/pages/03-core/core-line-chart.page.tsx
+++ b/pages/03-core/core-line-chart.page.tsx
@@ -60,17 +60,17 @@ const dataC = baseline.map(({ x, y }) => ({ x, y: y === null ? null : y + random
 
 const series: Highcharts.SeriesOptionsType[] = [
   {
-    name: "A",
+    name: "Very Long Series Name for Network Traffic Analysis Data Points",
     type: "line",
     data: dataA,
   },
   {
-    name: "B",
+    name: "Extremely Detailed Performance Metrics for Cloud Infrastructure",
     type: "line",
     data: dataB,
   },
   {
-    name: "C",
+    name: "Comprehensive System Resource Utilization Measurements Over Time",
     type: "line",
     data: dataC,
   },

--- a/pages/common/formatters.ts
+++ b/pages/common/formatters.ts
@@ -21,13 +21,32 @@ export function numberFormatter(value: null | number) {
   if (value === null) {
     return "";
   }
-  return Math.abs(value) >= 1e9
-    ? (value / 1e9).toFixed(1).replace(/\.0$/, "") + "G"
-    : Math.abs(value) >= 1e6
-      ? (value / 1e6).toFixed(1).replace(/\.0$/, "") + "M"
-      : Math.abs(value) >= 1e3
-        ? (value / 1e3).toFixed(1).replace(/\.0$/, "") + "K"
-        : value.toFixed(2);
+
+  const format = (num: number) => parseFloat(num.toFixed(2)).toString(); // trims unnecessary decimals
+
+  const absValue = Math.abs(value);
+
+  if (absValue === 0) {
+    return "0";
+  }
+
+  if (absValue < 0.01) {
+    return value.toExponential(0);
+  }
+
+  if (absValue >= 1e9) {
+    return format(value / 1e9) + "G";
+  }
+
+  if (absValue >= 1e6) {
+    return format(value / 1e6) + "M";
+  }
+
+  if (absValue >= 1e3) {
+    return format(value / 1e3) + "K";
+  }
+
+  return format(value);
 }
 
 export function moneyFormatter(value: null | number) {

--- a/src/core/__tests__/chart-core-axes.test.tsx
+++ b/src/core/__tests__/chart-core-axes.test.tsx
@@ -126,6 +126,7 @@ describe("CoreChart: axes", () => {
   test("uses default numeric axes formatters for integer values", () => {
     renderChart({ highcharts, options: { series, xAxis: { title: { text: "X" } }, yAxis: { title: { text: "Y" } } } });
     getAxisOptionsFormatters().forEach((formatter) => {
+      expect(formatter.call(mockAxisContext({ value: 0 }))).toBe("0");
       expect(formatter.call(mockAxisContext({ value: 1 }))).toBe("1");
       expect(formatter.call(mockAxisContext({ value: 1_000 }))).toBe("1K");
       expect(formatter.call(mockAxisContext({ value: 1_000_000 }))).toBe("1M");
@@ -138,6 +139,8 @@ describe("CoreChart: axes", () => {
     getAxisOptionsFormatters().forEach((formatter) => {
       expect(formatter.call(mockAxisContext({ value: 2.0 }))).toBe("2");
       expect(formatter.call(mockAxisContext({ value: 2.03 }))).toBe("2.03");
+      expect(formatter.call(mockAxisContext({ value: 0.03 }))).toBe("0.03");
+      expect(formatter.call(mockAxisContext({ value: 0.003 }))).toBe("3e-3");
     });
   });
 

--- a/src/core/__tests__/chart-core-tooltip.test.tsx
+++ b/src/core/__tests__/chart-core-tooltip.test.tsx
@@ -316,6 +316,45 @@ describe("CoreChart: tooltip", () => {
     }
   });
 
+  test("only re-renders when group has changed", () => {
+    const getTooltipContentMock = vi.fn(() => ({
+      header: () => "Tooltip title",
+      body: () => "Tooltip body",
+      footer: () => "Tooltip footer",
+    }));
+    renderChart({
+      highcharts,
+      options: {
+        series: lineSeries,
+        chart: {
+          events: {
+            load() {
+              this.plotTop = 0;
+              this.plotLeft = 0;
+              this.plotWidth = 100;
+              this.plotHeight = 100;
+            },
+          },
+        },
+      },
+      getTooltipContent: getTooltipContentMock,
+    });
+
+    act(() => {
+      hc.getChart().container.dispatchEvent(createMouseMoveEvent({ pageX: 1, pageY: 0 }));
+    });
+
+    act(() => {
+      hc.getChart().container.dispatchEvent(createMouseMoveEvent({ pageX: 1, pageY: 2 }));
+    });
+
+    act(() => {
+      hc.getChart().container.dispatchEvent(createMouseMoveEvent({ pageX: 1, pageY: 4 }));
+    });
+
+    expect(getTooltipContentMock).toHaveBeenCalledTimes(2);
+  });
+
   test("renders highlight markers", async () => {
     const { wrapper } = renderChart({
       highcharts,

--- a/src/core/chart-api/chart-extra-context.tsx
+++ b/src/core/chart-api/chart-extra-context.tsx
@@ -5,6 +5,7 @@ import type Highcharts from "highcharts";
 
 import { NonCancelableEventHandler } from "../../internal/events";
 import { getChartSeries } from "../../internal/utils/chart-series";
+import { getSeriesData } from "../../internal/utils/series-data";
 import { ChartLabels } from "../i18n-utils";
 import { CoreChartProps, Rect } from "../interfaces";
 import { getGroupRect, isSeriesStacked } from "../utils";
@@ -99,13 +100,13 @@ function computeDerivedState(chart: Highcharts.Chart): ChartExtraContext.Derived
   for (const s of getChartSeries(chart.series)) {
     const seriesX = new Set<number>();
     if (s.visible) {
-      for (const d of s.data) {
+      for (const d of getSeriesData(s.data)) {
         // Points with y=null represent the absence of value, there is no need to include them and those
         // should have no impact on computed rects or navigation.
 
         // Although "d" can't be undefined according to Highcharts API, it does become undefined for chart containing more datapoints
         // than the cropThreshold for that series (specific cases of re-rendering the chart with updated options listening to setExteme updates)
-        if (d && d.visible && d.y !== null) {
+        if (d.visible && d.y !== null) {
           seriesX.add(d.x);
           allXSet.add(d.x);
           addPoint(d);

--- a/src/core/chart-api/chart-extra-context.tsx
+++ b/src/core/chart-api/chart-extra-context.tsx
@@ -102,7 +102,10 @@ function computeDerivedState(chart: Highcharts.Chart): ChartExtraContext.Derived
       for (const d of s.data) {
         // Points with y=null represent the absence of value, there is no need to include them and those
         // should have no impact on computed rects or navigation.
-        if (d.visible && d.y !== null) {
+
+        // Although "d" can't be undefined according to Highcharts API, it does become undefined for chart containing more datapoints
+        // than the cropThreshold for that series (specific cases of re-rendering the chart with updated options listening to setExteme updates)
+        if (d && d.visible && d.y !== null) {
           seriesX.add(d.x);
           allXSet.add(d.x);
           addPoint(d);

--- a/src/core/chart-api/chart-extra-highlight.ts
+++ b/src/core/chart-api/chart-extra-highlight.ts
@@ -4,6 +4,7 @@
 import type Highcharts from "highcharts";
 
 import * as Styles from "../../internal/chart-styles";
+import { getSeriesData } from "../../internal/utils/series-data";
 import { getPointId, getSeriesId } from "../utils";
 import { ChartExtraContext } from "./chart-extra-context";
 
@@ -140,7 +141,7 @@ export class ChartExtraHighlight {
       if (prevState === "inactive") {
         inactiveSeriesIds.add(getSeriesId(s));
       }
-      for (const p of s.data) {
+      for (const p of getSeriesData(s.data)) {
         const prevState = this.pointState.get(getSeriesId(s))?.get(this.getPointKey(p));
         if (prevState) {
           this.setPointState(p, prevState);
@@ -183,7 +184,7 @@ export class ChartExtraHighlight {
         (overridden as SeriesSetStateWithLock)[SET_STATE_LOCK] = true;
         s.setState = overridden;
       }
-      for (const d of s.data) {
+      for (const d of getSeriesData(s.data)) {
         if ((d.setState as PointSetStateWithLock)[SET_STATE_LOCK] === undefined) {
           const original = d.setState;
           // The overridden setState method does nothing unless setState[SET_STATE_LOCK] === false.

--- a/src/core/chart-api/index.tsx
+++ b/src/core/chart-api/index.tsx
@@ -7,6 +7,7 @@ import type Highcharts from "highcharts";
 import { fireNonCancelableEvent } from "../../internal/events";
 import { ReadonlyAsyncStore } from "../../internal/utils/async-store";
 import { getChartSeries } from "../../internal/utils/chart-series";
+import { getSeriesData } from "../../internal/utils/series-data";
 import { Writeable } from "../../internal/utils/utils";
 import {
   getChartAccessibleDescription,
@@ -307,14 +308,15 @@ export class ChartAPI {
   private showMarkersForIsolatedPoints() {
     let shouldRedraw = false;
     for (const s of this.context.chart().series) {
-      for (let i = 0; i < s.data.length; i++) {
-        const isEligibleSeries = !isXThreshold(s) && s.type !== "scatter" && !s.data[i].options.marker?.enabled;
+      const seriesData = getSeriesData(s.data);
+      for (let i = 0; i < seriesData.length; i++) {
+        const isEligibleSeries = !isXThreshold(s) && s.type !== "scatter" && !seriesData[i].options.marker?.enabled;
         if (
           isEligibleSeries &&
-          (s.data[i - 1]?.y === undefined || s.data[i - 1]?.y === null) &&
-          (s.data[i + 1]?.y === undefined || s.data[i + 1]?.y === null)
+          (seriesData[i - 1]?.y === undefined || seriesData[i - 1]?.y === null) &&
+          (seriesData[i + 1]?.y === undefined || seriesData[i + 1]?.y === null)
         ) {
-          s.data[i].update({ marker: { enabled: true } }, false);
+          seriesData[i].update({ marker: { enabled: true } }, false);
           shouldRedraw = true;
         }
       }

--- a/src/core/formatters.tsx
+++ b/src/core/formatters.tsx
@@ -104,11 +104,28 @@ function secondFormatter(value: number) {
 
 function numberFormatter(value: number): string {
   const format = (num: number) => parseFloat(num.toFixed(2)).toString(); // trims unnecessary decimals
-  return Math.abs(value) >= 1e9
-    ? format(value / 1e9) + "G"
-    : Math.abs(value) >= 1e6
-      ? format(value / 1e6) + "M"
-      : Math.abs(value) >= 1e3
-        ? format(value / 1e3) + "K"
-        : format(value);
+
+  const absValue = Math.abs(value);
+
+  if (absValue === 0) {
+    return "0";
+  }
+
+  if (absValue < 0.01) {
+    return value.toExponential(0);
+  }
+
+  if (absValue >= 1e9) {
+    return format(value / 1e9) + "G";
+  }
+
+  if (absValue >= 1e6) {
+    return format(value / 1e6) + "M";
+  }
+
+  if (absValue >= 1e3) {
+    return format(value / 1e3) + "K";
+  }
+
+  return format(value);
 }

--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -421,7 +421,7 @@ const LegendItemTrigger = forwardRef(
         onKeyDown={onKeyDown}
       >
         {marker}
-        <span>{label}</span>
+        <span className={styles["item-label"]}>{label}</span>
       </button>
     );
   },

--- a/src/internal/components/chart-legend/styles.scss
+++ b/src/internal/components/chart-legend/styles.scss
@@ -73,6 +73,7 @@
   background-color: transparent;
   cursor: pointer;
   opacity: 1;
+  max-inline-size: 100%;
 
   &:focus {
     outline: none;
@@ -92,6 +93,14 @@
   &.item--dimmed {
     opacity: 0.35;
   }
+}
+
+.item-label {
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 3;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 }
 
 .actions {

--- a/src/internal/utils/series-data.ts
+++ b/src/internal/utils/series-data.ts
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Point } from "highcharts";
+
+// Although series data can't be undefined according to Highcharts API, it does become undefined for chart containing more datapoints
+// than the cropThreshold for that series (specific cases of re-rendering the chart with updated options listening to setExteme updates)
+export const getSeriesData = (data: Array<Point>): Array<Point> => {
+  return data.filter((d) => !!d);
+};


### PR DESCRIPTION
### Description

Adds proper handling of text overflow for long legend item labels.

#### Before

<img width="353" height="213" alt="Screenshot 2025-08-08 at 09 54 47" src="https://github.com/user-attachments/assets/abb6d514-493d-458d-b6b6-d666b48b8db3" />

#### After

<img width="353" height="219" alt="Screenshot 2025-08-08 at 09 54 23" src="https://github.com/user-attachments/assets/ea43064e-04e7-4fc8-b763-7e120a485ead" />