### PR TITLE
fix: handle text overflow for long legend item labels

### DIFF
--- a/pages/03-core/core-line-chart.page.tsx
+++ b/pages/03-core/core-line-chart.page.tsx
@@ -60,17 +60,17 @@ const dataC = baseline.map(({ x, y }) => ({ x, y: y === null ? null : y + random
 
 const series: Highcharts.SeriesOptionsType[] = [
   {
-    name: "A",
+    name: "Very Long Series Name for Network Traffic Analysis Data Points",
     type: "line",
     data: dataA,
   },
   {
-    name: "B",
+    name: "Extremely Detailed Performance Metrics for Cloud Infrastructure",
     type: "line",
     data: dataB,
   },
   {
-    name: "C",
+    name: "Comprehensive System Resource Utilization Measurements Over Time",
     type: "line",
     data: dataC,
   },

--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -421,7 +421,7 @@ const LegendItemTrigger = forwardRef(
         onKeyDown={onKeyDown}
       >
         {marker}
-        <span>{label}</span>
+        <span className={styles["item-label"]}>{label}</span>
       </button>
     );
   },

--- a/src/internal/components/chart-legend/styles.scss
+++ b/src/internal/components/chart-legend/styles.scss
@@ -73,6 +73,7 @@
   background-color: transparent;
   cursor: pointer;
   opacity: 1;
+  max-inline-size: 100%;
 
   &:focus {
     outline: none;
@@ -92,6 +93,14 @@
   &.item--dimmed {
     opacity: 0.35;
   }
+}
+
+.item-label {
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
 }
 
 .actions {


### PR DESCRIPTION
### Description

Adds proper handling of text overflow for long legend item labels.

<img width="1343" height="530" alt="Screenshot 2025-08-14 at 13 43 44" src="https://github.com/user-attachments/assets/fbdff987-c640-499e-876a-b9f3866e9afc" />