### PR TITLE
fix(noData): remove dynamically calculated style position attributes …

### DIFF
--- a/src/core/chart-api/chart-extra-nodata.tsx
+++ b/src/core/chart-api/chart-extra-nodata.tsx
@@ -11,7 +11,7 @@ import { ChartExtraContext } from "./chart-extra-context";
 // It can be used by other components to assert if the chart is in no-data state (by checking if container is present).
 export interface ReactiveNodataState {
   visible: boolean;
-  style: React.CSSProperties;
+  style?: React.CSSProperties;
   noMatch: boolean;
 }
 
@@ -32,17 +32,11 @@ export class ChartExtraNodata extends AsyncStore<ReactiveNodataState> {
     const visibleSeries = findAllVisibleSeries(this.chart);
     // The no-data is not shown when there is at least one series or point (for pie series) non-empty and visible.
     if (visibleSeries.length > 0) {
-      this.set(() => ({ visible: false, style: {}, noMatch: false }));
+      this.set(() => ({ visible: false, noMatch: false }));
     } else {
-      this.set(() => ({ visible: true, style: this.getContainerStyle(), noMatch: allSeriesWithData.length > 0 }));
+      this.set(() => ({ visible: true, noMatch: allSeriesWithData.length > 0 }));
     }
   };
-
-  private getContainerStyle(): React.CSSProperties {
-    const inlineOffset = this.chart.chartWidth - this.chart.plotWidth;
-    const blockOffset = this.chart.chartHeight - this.chart.plotHeight;
-    return { insetInlineStart: `${inlineOffset}px`, insetBlockEnd: `${blockOffset}px` };
-  }
 
   private get chart() {
     return this.context.chart();


### PR DESCRIPTION
…allowing flex container  to center it

### Description

This change removes the positioning styles set for noData containers as the resulting positioning produces an unfavorable outcome. This is more visible on small widget sized charts and on dashboards. 

The current beaviour is seting `inset-block-end` and `inset-inline-start` css params (these are corresponding to `left`, `top` attributes but writing direction agnositc.)

From the logic implemented it seems that `left` is set to be the difference between Chart width and plot area (diff can be a sum of yAxis, yAxis title, width of side positioned legend etc.)

| noData before | noData after |
| ---------- | ----------|
| <img width="1608" height="8965" alt="no-data-before" src="https://github.com/user-attachments/assets/09b28ebf-9a28-49d7-be0b-c5c069ed7a61" /> | <img width="1908" height="8789" alt="noData" src="https://github.com/user-attachments/assets/bf2bf54e-e10c-48b4-83e5-08d7ff1dd776" /> |

| error | loading | noData wide |
| ---------- | ---------- | ---------- |
|<img width="1622" height="8965" alt="error" src="https://github.com/user-attachments/assets/c139b7ab-985f-42d0-9c3a-05ba6167769a" />|<img width="1622" height="8965" alt="loading" src="https://github.com/user-attachments/assets/efbbb1de-56ac-4768-93fc-78813b28a374" />|<img width="2364" height="8325" alt="noDataWide" src="https://github.com/user-attachments/assets/1aa47aa4-6c8b-4abb-8485-d81e2ad0862e" />|


### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
