### PR TITLE
fix: align series detail for arbitrary actions

### DIFF
--- a/src/internal/components/series-details/styles.scss
+++ b/src/internal/components/series-details/styles.scss
@@ -36,6 +36,7 @@ $font-weight-bold: cs.$font-weight-heading-s;
   flex-direction: row;
   justify-content: space-between;
   inline-size: 100%;
+  align-items: center;
 
   > .key {
     @include styles.text-wrapping;
@@ -101,7 +102,7 @@ $font-weight-bold: cs.$font-weight-heading-s;
 
 .highlight-indicator {
   position: absolute;
-  top: 3px;
+  margin-top: 3px;
   left: -6px;
   inline-size: 3px;
   block-size: calc(marker.$marker-size - 2px);


### PR DESCRIPTION
### Description

The `getTooltipContent` prop allows the consumer to pass an arbitrary React nodes in the data point tooltip. For certain cases though, the content is not vertically aligned.

In this commit, I am fixing that by using `align-items: center` to center the content vertically.

Doing so however breaks the positioning of the highlight indicator. To fix that, I moved the highlight indicator next to the marker which puts it inside a more appropriate parent and enables the desired positioning.

Related links, issue #, if available: n/a

### How has this been tested?

Tested the following:
* Vertical alignment for arbitrary content
* Hightlight indicator positioning
* Scrollling the selected series into view in the tooltip

#### Before
<img width="987" height="796" alt="Screenshot 2025-08-15 at 6 40 51 p m" src="https://github.com/user-attachments/assets/4b987fa1-c1b9-48a3-9f5a-475eaf5adac9" />

#### After
<img width="987" height="796" alt="Screenshot 2025-08-15 at 6 39 27 p m" src="https://github.com/user-attachments/assets/549b0ac0-aabb-49a8-9285-5cb193aa5745" />|

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
