### PR TITLE
fix: prevent early truncation in legend items

### DIFF
--- a/src/internal/components/chart-legend/styles.scss
+++ b/src/internal/components/chart-legend/styles.scss
@@ -51,6 +51,7 @@
   display: flex;
   flex-wrap: wrap;
   flex-direction: row;
+  max-inline-size: 100%;
   gap: cs.$space-scaled-xxs cs.$space-static-m;
 }
 
@@ -97,6 +98,8 @@
 
 .item-label {
   overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   display: -webkit-box;
   line-clamp: 1;
   -webkit-line-clamp: 1;


### PR DESCRIPTION
### Description

#### Demo Page
<img width="704" height="527" alt="Screenshot 2025-08-19 at 16 45 13" src="https://github.com/user-attachments/assets/62cf6dbc-6930-4e36-be50-11e00d0e9368" />