### PR TITLE
fix: filter undefined series points

### DIFF
--- a/src/core/chart-api/chart-extra-legend.tsx
+++ b/src/core/chart-api/chart-extra-legend.tsx
@@ -7,6 +7,7 @@ import { ChartSeriesMarker, ChartSeriesMarkerType } from "../../internal/compone
 import { fireNonCancelableEvent } from "../../internal/events";
 import AsyncStore from "../../internal/utils/async-store";
 import { getChartSeries } from "../../internal/utils/chart-series";
+import { getSeriesData } from "../../internal/utils/series-data";
 import { isEqualArrays } from "../../internal/utils/utils";
 import { CoreChartProps } from "../interfaces";
 import { getChartLegendItems, getPointId, getSeriesId } from "../utils";
@@ -134,7 +135,7 @@ function updateItemsVisibility(
     if (availableItemsSet.has(getSeriesId(series))) {
       series.setVisible(getVisibleAndCount(getSeriesId(series), series.visible), false);
     }
-    for (const point of series.data) {
+    for (const point of getSeriesData(series.data)) {
       if (typeof point.setVisible === "function" && availableItemsSet.has(getPointId(point))) {
         point.setVisible(getVisibleAndCount(getPointId(point), point.visible), false);
       }

--- a/src/core/chart-api/chart-extra-navigation.ts
+++ b/src/core/chart-api/chart-extra-navigation.ts
@@ -12,6 +12,7 @@ import {
 
 import * as Styles from "../../internal/chart-styles";
 import { SVGRendererPool } from "../../internal/utils/renderer-utils";
+import { getSeriesData } from "../../internal/utils/series-data";
 import { Rect } from "../interfaces";
 import { getGroupRect, getPointRect, isPointVisible, isXThreshold } from "../utils";
 import { ChartExtraContext } from "./chart-extra-context";
@@ -447,40 +448,40 @@ export class ChartExtraNavigation {
 
   private findFirstPointInSeries = (point: Highcharts.Point): null | Highcharts.Point => {
     const seriesX = this.getAllXInSeries(point.series);
-    return point.series.data.find((d) => d.x === seriesX[0]) ?? null;
+    return getSeriesData(point.series.data).find((d) => d.x === seriesX[0]) ?? null;
   };
 
   private findLastPointInSeries = (point: Highcharts.Point): null | Highcharts.Point => {
     const seriesX = this.getAllXInSeries(point.series);
-    return point.series.data.find((d) => d.x === seriesX[seriesX.length - 1]) ?? null;
+    return getSeriesData(point.series.data).find((d) => d.x === seriesX[seriesX.length - 1]) ?? null;
   };
 
   private findNextPointInSeries = (point: Highcharts.Point): null | Highcharts.Point => {
     const seriesX = this.getAllXInSeries(point.series);
     const delta = !shouldInvertPointsDirection(point) ? 1 : -1;
     const nextIndex = getNextIndex(seriesX, seriesX.indexOf(point.x), delta);
-    return point.series.data.find((d) => d.x === seriesX[nextIndex]) ?? null;
+    return getSeriesData(point.series.data).find((d) => d.x === seriesX[nextIndex]) ?? null;
   };
 
   private findPrevPointInSeries = (point: Highcharts.Point): null | Highcharts.Point => {
     const seriesX = this.getAllXInSeries(point.series);
     const delta = !shouldInvertPointsDirection(point) ? -1 : 1;
     const nextIndex = getNextIndex(seriesX, seriesX.indexOf(point.x), delta);
-    return point.series.data.find((d) => d.x === seriesX[nextIndex]) ?? null;
+    return getSeriesData(point.series.data).find((d) => d.x === seriesX[nextIndex]) ?? null;
   };
 
   private findNextPagePointInSeries = (point: Highcharts.Point): null | Highcharts.Point => {
     const seriesX = this.getAllXInSeries(point.series);
     const delta = !shouldInvertPointsDirection(point) ? 1 : -1;
     const nextIndex = getNextPageIndex(seriesX, seriesX.indexOf(point.x), delta);
-    return point.series.data.find((d) => d.x === seriesX[nextIndex]) ?? null;
+    return getSeriesData(point.series.data).find((d) => d.x === seriesX[nextIndex]) ?? null;
   };
 
   private findPrevPagePointInSeries = (point: Highcharts.Point): null | Highcharts.Point => {
     const seriesX = this.getAllXInSeries(point.series);
     const delta = !shouldInvertPointsDirection(point) ? -1 : 1;
     const nextIndex = getNextPageIndex(seriesX, seriesX.indexOf(point.x), delta);
-    return point.series.data.find((d) => d.x === seriesX[nextIndex]) ?? null;
+    return getSeriesData(point.series.data).find((d) => d.x === seriesX[nextIndex]) ?? null;
   };
 }
 


### PR DESCRIPTION
### Description

Fixes crashing bugs that may arise when iterating chart series with undefined points. I still haven't been able to reproduce this  issue in one of the demo pages.

<img width="1570" height="1032" alt="Screenshot 2025-08-21 at 10 27 06" src="https://github.com/user-attachments/assets/a758d11c-fd0e-48ba-ab58-0ea69e2514d3" />

<img width="1444" height="308" alt="Screenshot 2025-08-21 at 10 27 57" src="https://github.com/user-attachments/assets/b3065123-020b-4c31-af6c-d40f8010481f" />
