### PR TITLE
Add color handling for solid gauge charts

### DIFF
--- a/src/core/__tests__/chart-core-utils.test.tsx
+++ b/src/core/__tests__/chart-core-utils.test.tsx
@@ -1,7 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getPointColor, getSeriesColor, getSeriesMarkerType } from "../../../lib/components/core/utils";
+import {
+  getColor,
+  getPointColor,
+  getSeriesColor,
+  getSeriesMarkerType,
+  getSolidGaugeColor,
+} from "../../../lib/components/core/utils";
 
 describe("CoreChart: utils", () => {
   test.each([
@@ -35,4 +41,129 @@ describe("CoreChart: utils", () => {
       expect(method({ color: 12345 })).toBe("black");
     },
   );
+
+  describe("getSolidGaugeColor", () => {
+    test("returns color from yAxis stops if available", () => {
+      const yAxis = {
+        stops: [
+          ["0%", "#ff0000"],
+          ["100%", "#00ff00"],
+        ],
+      } as any;
+      expect(getSolidGaugeColor(yAxis)).toBe("#ff0000");
+    });
+
+    test("returns black if no stops available", () => {
+      expect(getSolidGaugeColor(undefined)).toBe("black");
+      expect(getSolidGaugeColor({} as any)).toBe("black");
+      expect(getSolidGaugeColor({ stops: [] } as any)).toBe("black");
+      expect(getSolidGaugeColor({ stops: [[]] } as any)).toBe("black");
+    });
+
+    test("returns black if stop color is not a string", () => {
+      const yAxis = {
+        stops: [["0%", 123]],
+      } as any;
+      expect(getSolidGaugeColor(yAxis)).toBe("black");
+    });
+
+    test("handles malformed stops arrays", () => {
+      // Non-array stops
+      expect(getSolidGaugeColor({ stops: "invalid" } as any)).toBe("black");
+
+      // Empty first stop
+      expect(getSolidGaugeColor({ stops: [[]] } as any)).toBe("black");
+
+      // First stop with only one element
+      expect(getSolidGaugeColor({ stops: [["0%"]] } as any)).toBe("black");
+
+      // Non-array first stop
+      expect(getSolidGaugeColor({ stops: ["invalid"] } as any)).toBe("black");
+    });
+  });
+
+  describe("getColor", () => {
+    test("calls getSolidGaugeColor for solidgauge series", () => {
+      const chart = {
+        series: [{ type: "solidgauge" }],
+        yAxis: [{ stops: [["0%", "#ff0000"]] }],
+      } as any;
+
+      const result = getColor(chart, 0);
+      expect(result).toBe("#ff0000");
+    });
+
+    test("calls getSeriesColor for non-solidgauge series", () => {
+      const chart = {
+        series: [{ type: "line", color: "#00ff00" }],
+        yAxis: [{}],
+      } as any;
+
+      const result = getColor(chart, 0);
+      expect(result).toBe("#00ff00");
+    });
+
+    test("correctly identifies solidgauge vs other series types", () => {
+      const chart = {
+        series: [
+          { type: "line", color: "#blue" },
+          { type: "solidgauge" },
+          { type: "column", color: "#green" },
+          { type: "solidgauge" },
+        ],
+        yAxis: [{}, { stops: [["0%", "#red"]] }, {}, { stops: [["0%", "#yellow"]] }],
+      } as any;
+
+      // Line series should use getSeriesColor
+      expect(getColor(chart, 0)).toBe("#blue");
+
+      // First solidgauge should use getSolidGaugeColor
+      expect(getColor(chart, 1)).toBe("#red");
+
+      // Column series should use getSeriesColor
+      expect(getColor(chart, 2)).toBe("#green");
+
+      // Second solidgauge should use getSolidGaugeColor
+      expect(getColor(chart, 3)).toBe("#yellow");
+    });
+
+    test("handles edge cases gracefully", () => {
+      // Missing series
+      const emptyChart = { series: [], yAxis: [] } as any;
+      expect(getColor(emptyChart, 0)).toBe("black");
+
+      // Out of bounds index
+      const chart = {
+        series: [{ type: "line", color: "#blue" }],
+        yAxis: [{}],
+      } as any;
+      expect(getColor(chart, 5)).toBe("black");
+
+      // Solidgauge with missing yAxis
+      const chartMissingYAxis = {
+        series: [{ type: "solidgauge" }],
+        yAxis: [],
+      } as any;
+      expect(getColor(chartMissingYAxis, 0)).toBe("black");
+
+      // Null/undefined series
+      expect(getColor({ series: [null], yAxis: [] } as any, 0)).toBe("black");
+    });
+
+    test("case sensitivity of series type", () => {
+      const chart = {
+        series: [
+          { type: "solidgauge" },
+          { type: "SOLIDGAUGE" }, // Different case
+          { type: "SolidGauge" }, // Mixed case
+        ],
+        yAxis: [{ stops: [["0%", "#red"]] }, { stops: [["0%", "#blue"]] }, { stops: [["0%", "#green"]] }],
+      } as any;
+
+      // Only exact match "solidgauge" should use getSolidGaugeColor
+      expect(getColor(chart, 0)).toBe("#red");
+      expect(getColor(chart, 1)).toBe("black"); // Should fall back to getSeriesColor -> black
+      expect(getColor(chart, 2)).toBe("black"); // Should fall back to getSeriesColor -> black
+    });
+  });
 });

--- a/src/core/components/core-tooltip.tsx
+++ b/src/core/components/core-tooltip.tsx
@@ -14,7 +14,7 @@ import { getChartSeries } from "../../internal/utils/chart-series";
 import { ChartAPI } from "../chart-api";
 import { getFormatter } from "../formatters";
 import { BaseI18nStrings, CoreChartProps } from "../interfaces";
-import { getPointColor, getSeriesColor, getSeriesId, getSeriesMarkerType, isXThreshold } from "../utils";
+import { getColor, getPointColor, getSeriesId, getSeriesMarkerType, isXThreshold } from "../utils";
 
 import styles from "../styles.css.js";
 
@@ -144,17 +144,17 @@ function getTooltipContentCartesian(
   // By design, every point of the group has the same x value.
   const x = group[0].x;
   const chart = group[0].series.chart;
-  const getSeriesMarker = (series: Highcharts.Series) =>
-    api.renderMarker(getSeriesMarkerType(series), getSeriesColor(series), true);
+  const getSeriesMarker = (series: Highcharts.Series, idx: number) =>
+    api.renderMarker(getSeriesMarkerType(series), getColor(chart, idx), true);
   const matchedItems = findTooltipSeriesItems(getChartSeries(chart.series), group);
-  const detailItems: ChartSeriesDetailItem[] = matchedItems.map((item) => {
+  const detailItems: ChartSeriesDetailItem[] = matchedItems.map((item, idx) => {
     const valueFormatter = getFormatter(item.point.series.yAxis);
     const itemY = isXThreshold(item.point.series) ? null : (item.point.y ?? null);
     const customContent = renderers.point ? renderers.point({ item }) : undefined;
     return {
       key: customContent?.key ?? item.point.series.name,
       value: customContent?.value ?? valueFormatter(itemY),
-      marker: getSeriesMarker(item.point.series),
+      marker: getSeriesMarker(item.point.series, idx),
       subItems: customContent?.subItems,
       expandableId: customContent?.expandable ? item.point.series.name : undefined,
       highlighted: item.point.x === point?.x && item.point.y === point?.y,

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -118,8 +118,71 @@ export function getSeriesMarkerType(series?: Highcharts.Series): ChartSeriesMark
 export function getSeriesColor(series?: Highcharts.Series): string {
   return typeof series?.color === "string" ? series.color : "black";
 }
+
+/**
+ * Extracts the color value from a solid gauge yAxis stops configuration.
+ * @param yAxis - The Highcharts yAxis object
+ * @returns The color string from the first stop, or "black" as fallback
+ */
+export function getSolidGaugeColor(yAxis?: Highcharts.Axis): string {
+  if (!yAxis) {
+    return "black";
+  }
+
+  try {
+    const yAxisOptions = yAxis as unknown as Highcharts.YAxisOptions;
+    const stops = yAxisOptions?.stops;
+
+    // Check if stops exists and is a proper array
+    if (!stops || !Array.isArray(stops) || stops.length === 0) {
+      return "black";
+    }
+
+    const firstStop = stops[0];
+
+    // Ensure firstStop is an array with at least 2 elements
+    if (!firstStop || !Array.isArray(firstStop) || firstStop.length < 2) {
+      return "black";
+    }
+
+    const colorValue = firstStop[1];
+    return typeof colorValue === "string" ? colorValue : "black";
+  } catch {
+    return "black";
+  }
+}
 export function getPointColor(point?: Highcharts.Point): string {
   return typeof point?.color === "string" ? point.color : "black";
+}
+
+/**
+ * Gets the appropriate color for a chart series based on its type.
+ * For solid gauge series, extracts color from yAxis stops.
+ * For other series types, uses the series color property.
+ * @param chart - The Highcharts chart object
+ * @param index - The index of the series in the chart
+ * @returns The color string for the series, or "black" as fallback
+ */
+export function getColor(chart: Highcharts.Chart, index: number): string {
+  // Check if chart and series array exist
+  if (!chart || !chart.series || !Array.isArray(chart.series)) {
+    return "black";
+  }
+
+  const series = chart.series[index];
+  if (!series || series === null || series === undefined) {
+    return "black";
+  }
+
+  if (series.type === "solidgauge") {
+    // Ensure yAxis array exists and has the required index
+    if (!chart.yAxis || !Array.isArray(chart.yAxis) || !chart.yAxis[index]) {
+      return "black";
+    }
+    return getSolidGaugeColor(chart.yAxis[index]);
+  }
+
+  return getSeriesColor(series);
 }
 
 // The custom legend implementation does not rely on the Highcharts legend. When Highcharts legend is disabled,
@@ -130,7 +193,7 @@ export function getPointColor(point?: Highcharts.Point): string {
 // Highcharts legend is disabled. Instead, we use this custom method to collect legend items from the chart.
 export function getChartLegendItems(chart: Highcharts.Chart): readonly LegendItemSpec[] {
   const legendItems: LegendItemSpec[] = [];
-  const addSeriesItem = (series: Highcharts.Series) => {
+  const addSeriesItem = (series: Highcharts.Series, index: number) => {
     // The pie series is not shown in the legend. Instead, we show pie segments.
     if (series.type === "pie") {
       return;
@@ -147,7 +210,7 @@ export function getChartLegendItems(chart: Highcharts.Chart): readonly LegendIte
         id: getSeriesId(series),
         name: series.name,
         markerType: getSeriesMarkerType(series),
-        color: getSeriesColor(series),
+        color: getColor(chart, index),
         visible: series.visible,
       });
     }
@@ -163,8 +226,8 @@ export function getChartLegendItems(chart: Highcharts.Chart): readonly LegendIte
       });
     }
   };
-  for (const s of getChartSeries(chart.series)) {
-    addSeriesItem(s);
+  for (const [i, s] of getChartSeries(chart.series).entries()) {
+    addSeriesItem(s, i);
     s.data.forEach(addPointItem);
   }
   return legendItems;


### PR DESCRIPTION
### Description
![](https://monitorportal.amazon.com/snap/load/snap.250822133243.eTj0gRUg.png)

- Implement getSolidGaugeColor() to extract colors from yAxis stops
- Add getColor() utility to handle both solid gauge and regular series colors
- Update tooltip and legend components to use new color utilities


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

Tested manually 

<!-- How can reviewers test these changes efficiently? -->

Create a gauge example using Highcharts solidgauge module.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
