### PR TITLE
chore: Migrate to new test-utils doc generator

### DIFF
--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -3,9 +3,7 @@
 
 import path from "node:path";
 
-import { documentTestUtils, writeComponentsDocumentation } from "@cloudscape-design/documenter";
-
-import { writeSourceFile } from "./utils.js";
+import { writeComponentsDocumentation, writeTestUtilsDocumentation } from "@cloudscape-design/documenter";
 
 const targetDir = "lib/components/internal/api-docs";
 
@@ -21,16 +19,16 @@ function componentDocs() {
 }
 
 function testUtilDocs() {
-  const tsconfig = path.resolve("src/test-utils/tsconfig.json");
-  ["dom", "selectors"].forEach((testUtilType) => {
-    const componentWrapperDefinitions = documentTestUtils({ tsconfig }, `**/{${testUtilType},types}/**/*`);
-
-    const indexContent = `module.exports = {
-      classes: ${JSON.stringify(componentWrapperDefinitions)}
-    }
-    `;
-
-    const outPath = path.join(targetDir, "test-utils-doc", `${testUtilType}.js`);
-    writeSourceFile(outPath, indexContent);
+  writeTestUtilsDocumentation({
+    outDir: path.join(targetDir, "test-utils-doc"),
+    tsconfigPath: path.resolve("src/test-utils/tsconfig.json"),
+    domUtils: {
+      root: "src/test-utils/dom/index.ts",
+      extraExports: ["default", "ElementWrapper"],
+    },
+    selectorsUtils: {
+      root: "src/test-utils/selectors/index.ts",
+      extraExports: ["default", "ElementWrapper"],
+    },
   });
 }


### PR DESCRIPTION
### Description

Port that change https://github.com/cloudscape-design/components/pull/3802 to the current package

Related links, issue #, if available: n/a

### How has this been tested?

PR build, no differences in snapshots

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
