### PR TITLE
fix: prevent list-bottom container from becoming scrollable

### DIFF
--- a/src/internal/components/chart-legend/styles.scss
+++ b/src/internal/components/chart-legend/styles.scss
@@ -37,7 +37,6 @@
 
 .list-bottom {
   flex-wrap: wrap;
-  overflow-y: auto;
   justify-content: space-between;
 }
 


### PR DESCRIPTION
### Description

The CW console currently displays two scrollable containers for global legend widgets due to both `awsui_root` and `awsui_list` elements having scroll enabled.

This fix removes the scrollable property from `awsui_list`, maintaining it only on `awsui_root`. As far as I'm aware, there's no identified use case for `awsui_list` to be scrollable since `awsui_root` is the intended container for handling automatic legend scrolling on highlight changes.

<img width="753" height="38" alt="Screenshot 2025-09-19 at 16 35 53" src="https://github.com/user-attachments/assets/4ee6482c-45b5-4d8c-bfd7-542ca96cc82b" />

<img width="640" height="360" alt="Screenshot 2025-09-19 at 16 35 03" src="https://github.com/user-attachments/assets/be1e12b5-8683-4bab-afee-46fd4f61df4f" />
