### PR TITLE
fix: handle additional undefined series

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -159,7 +159,7 @@ export function getChartLegendItems(chart: Highcharts.Chart): readonly LegendIte
     }
   };
   const addPointItem = (point: Highcharts.Point, isSecondary: boolean) => {
-    if (point.series.type === "pie") {
+    if (point?.series?.type === "pie") {
       legendItems.push({
         id: getPointId(point),
         name: point.name,


### PR DESCRIPTION
### Description

A very niche case of point being null causing charts to crash in CloudWatch Console.

Only manage to reproduce in CloudWatch.

Optional chaining the access to series to handle null/undefined cases.

### How has this been tested?

Tested in CloudWatch Console.

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
