### PR TITLE
fix: re-render legend when `isSecondary` changes

### DIFF
--- a/src/core/__tests__/chart-core-legend.test.tsx
+++ b/src/core/__tests__/chart-core-legend.test.tsx
@@ -657,6 +657,72 @@ describe("CoreChart: secondary legend", () => {
     );
   });
 
+  test("updates legend partition when a series moves from primary to secondary y-axis", () => {
+    const seriesOnPrimary: Highcharts.SeriesOptionsType[] = [
+      { type: "line", name: "Primary 1", data: [1, 2, 3], yAxis: 0 },
+      { type: "line", name: "Movable", data: [4, 5, 6], yAxis: 0 },
+      { type: "line", name: "Secondary 1", data: [10, 20, 30], yAxis: 1 },
+    ];
+    const seriesOnSecondary: Highcharts.SeriesOptionsType[] = [
+      { type: "line", name: "Primary 1", data: [1, 2, 3], yAxis: 0 },
+      { type: "line", name: "Movable", data: [4, 5, 6], yAxis: 1 },
+      { type: "line", name: "Secondary 1", data: [10, 20, 30], yAxis: 1 },
+    ];
+
+    const { rerender } = renderChart({ highcharts, options: { series: seriesOnPrimary, yAxis: yAxes } });
+
+    // Initially, "Movable" is on primary legend.
+    const initialPrimaryItems = createChartWrapper()
+      .findLegend()!
+      .findItems()
+      .map((w) => w.getElement().textContent);
+    const initialSecondaryItems = createChartWrapper()
+      .findLegend({ axisId: "secondary" })!
+      .findItems()
+      .map((w) => w.getElement().textContent);
+    expect(initialPrimaryItems).toEqual(["Primary 1", "Movable"]);
+    expect(initialSecondaryItems).toEqual(["Secondary 1"]);
+
+    // After moving "Movable" to the secondary axis, the legend partitions should reflect the new axis.
+    rerender({ highcharts, options: { series: seriesOnSecondary, yAxis: yAxes } });
+
+    const updatedPrimaryItems = createChartWrapper()
+      .findLegend()!
+      .findItems()
+      .map((w) => w.getElement().textContent);
+    const updatedSecondaryItems = createChartWrapper()
+      .findLegend({ axisId: "secondary" })!
+      .findItems()
+      .map((w) => w.getElement().textContent);
+    expect(updatedPrimaryItems).toEqual(["Primary 1"]);
+    expect(updatedSecondaryItems).toEqual(["Movable", "Secondary 1"]);
+  });
+
+  test("legend disappears and reappears on the correct side when the only series moves axes", () => {
+    const onlyOnPrimary: Highcharts.SeriesOptionsType[] = [{ type: "line", name: "Solo", data: [1, 2, 3], yAxis: 0 }];
+    const onlyOnSecondary: Highcharts.SeriesOptionsType[] = [{ type: "line", name: "Solo", data: [1, 2, 3], yAxis: 1 }];
+
+    const { rerender } = renderChart({ highcharts, options: { series: onlyOnPrimary, yAxis: yAxes } });
+
+    expect(
+      createChartWrapper()
+        .findLegend()!
+        .findItems()
+        .map((w) => w.getElement().textContent),
+    ).toEqual(["Solo"]);
+    expect(createChartWrapper().findLegend({ axisId: "secondary" })).toBe(null);
+
+    rerender({ highcharts, options: { series: onlyOnSecondary, yAxis: yAxes } });
+
+    expect(createChartWrapper().findLegend()).toBe(null);
+    expect(
+      createChartWrapper()
+        .findLegend({ axisId: "secondary" })!
+        .findItems()
+        .map((w) => w.getElement().textContent),
+    ).toEqual(["Solo"]);
+  });
+
   describe("Event handlers", () => {
     test("calls onLegendItemHighlight when hovering secondary legend item", () => {
       const onLegendItemHighlight = vi.fn();

--- a/src/core/chart-api/chart-extra-legend.tsx
+++ b/src/core/chart-api/chart-extra-legend.tsx
@@ -106,7 +106,8 @@ export class ChartExtraLegend extends AsyncStore<ReactiveLegendState> {
         a.name === b.name &&
         a.marker === b.marker &&
         a.visible === b.visible &&
-        a.highlighted === b.highlighted
+        a.highlighted === b.highlighted &&
+        a.isSecondary === b.isSecondary
       );
     }
     if (!isEqualArrays(this.get().items, nextItems, isLegendItemsEqual)) {


### PR DESCRIPTION
### Description

Previously, updating a series to the left axis to the right axis updated the chart, but not the legend. This was due to a missing check in the `ChartExtraLegend`.

### How has this been tested?


https://github.com/user-attachments/assets/de8183eb-a503-438d-beb2-599b8177797e

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- ✅  _Changes include appropriate documentation updates._
- ✅ _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- ✅ _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- ✅ _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- ✅ _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- ✅ _Changes are covered with new/existing unit tests?_
- ✅ _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
