### PR TITLE
chore: add eslint warning for accessing series.data directly

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -124,6 +124,10 @@
             "selector": "MemberExpression[property.name='data'][object.type='TSAsExpression'][object.typeAnnotation.typeName.name='Series']",
             "message": "Direct (x as Series).data access is unsafe due to Highcharts cropThreshold sparse arrays. Use getSeriesData() instead.",
           },
+          {
+            "selector": "MemberExpression[property.name='series'][object.type='TSAsExpression'][object.typeAnnotation.typeName.name='Chart']",
+            "message": "Direct (x as Chart).series access may include internal series. Use getChartSeries() instead.",
+          },
         ],
       },
     },

--- a/.eslintrc
+++ b/.eslintrc
@@ -120,6 +120,10 @@
             "selector": "ImportDeclaration[source.value='highcharts'][importKind='value']",
             "message": "Use `import type Highcharts from 'highcharts'` instead of regular import.",
           },
+          {
+            "selector": "MemberExpression[property.name='data'][object.type='TSAsExpression'][object.typeAnnotation.typeName.name='Series']",
+            "message": "Direct (x as Series).data access is unsafe due to Highcharts cropThreshold sparse arrays. Use getSeriesData() instead.",
+          },
         ],
       },
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,7 @@ This project uses npm.
 ## Conventions
 
 This repository follows the same conventions as the [main Cloudscape components library](https://github.com/cloudscape-design/components). Refer to the [Cloudscape Components Guide](https://github.com/cloudscape-design/components/blob/main/docs/CLOUDSCAPE_COMPONENTS_GUIDE.md) for details on component structure, props, events, styling, testing, code style, dev pages, and API docs.
+
+## Highcharts
+
+Never access `series.data` directly — use `getSeriesData()` from `src/internal/utils/highcharts`. See the [Highcharts pitfalls section in CONTRIBUTING.md](CONTRIBUTING.md#highcharts-pitfalls) for details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,30 @@ For more information on our support model, versioning, browsers and frameworks s
 Currently we only accept code contributions for bug fixes. A code owner will review the pull request and merge it. Once we merge a pull request, we run additional testing internally before publishing artifacts to npm.
 
 
+## Highcharts pitfalls
+
+### Never access `series.data` directly
+
+Highcharts has a performance optimization called [`cropThreshold`](https://api.highcharts.com/highcharts/plotOptions.series.cropThreshold) (default: 300 for line series, 50 for column/bar). When a series exceeds this threshold **and** the axis extremes are narrower than the full data range, Highcharts allocates `series.data` to full length but only populates elements from `cropStart` onward — earlier indexes are `undefined`.
+
+Accessing `series.data` directly (e.g., `.find()`, `.forEach()`, index access) will crash on these `undefined` entries.
+
+**Do this instead:**
+
+```ts
+import { getSeriesData } from "../internal/utils/highcharts";
+
+// Safe — filters out undefined/destroyed points
+for (const point of getSeriesData(series)) { ... }
+
+// Unsafe — will crash with >300 points and narrowed axis
+(series as Series).data.find(d => d.x === target);
+```
+
+The `SafeSeries` type omits `.data` so TypeScript prevents direct access.
+
+
+
 ## Code of Conduct
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
 For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact

--- a/src/internal/utils/highcharts.ts
+++ b/src/internal/utils/highcharts.ts
@@ -27,6 +27,7 @@ interface InternalSeries extends Series {
  * navigator is causing duplicated unexpected datapoints and series entries in the chart.
  */
 export function getChartSeries(chart: SafeChart): SafeSeries[] {
+  // eslint-disable-next-line no-restricted-syntax -- This is the safe wrapper itself.
   return (chart as Chart).series?.filter((s: InternalSeries) => !s.options.isInternal) ?? [];
 }
 
@@ -66,17 +67,10 @@ export function isPointVisible(point?: Point) {
 }
 
 /**
- * Returns the series data points, filtering out undefined/destroyed entries.
- *
- * @warning **Never access `series.data` directly.** Highcharts' `cropThreshold` optimization
- * (default: 300 for line, 50 for column/bar) makes `series.data` a sparse array when the dataset
- * exceeds the threshold and axis extremes are narrower than the full data range. Elements before
- * `cropStart` are left as `undefined`, causing crashes on property access (e.g., `.find(d => d.x)`).
- *
- * The `SafeSeries` type omits `.data` to enforce this at compile time. If you see a cast to
- * `Series` to access `.data`, it is almost certainly a bug — use this function instead.
- *
- * See: https://api.highcharts.com/highcharts/plotOptions.series.cropThreshold
+ * The series may include undefined points. See: https://api.highcharts.com/class-reference/Highcharts.Series.html#data,
+ * and https://github.com/highcharts/highcharts/issues/11116.
+ * This can create issues when iterating over the data (using Array.filter() or Array.map() methods is safe, but index access or Array.find()
+ * can cause a crash if accessing point's properties without checking).
  */
 export const getSeriesData = (series: SafeSeries, options: { includeHiddenPoints?: boolean } = {}): Array<Point> => {
   // eslint-disable-next-line no-restricted-syntax -- This is the safe wrapper itself.

--- a/src/internal/utils/highcharts.ts
+++ b/src/internal/utils/highcharts.ts
@@ -66,11 +66,19 @@ export function isPointVisible(point?: Point) {
 }
 
 /**
- * The series may include undefined points. See: https://api.highcharts.com/class-reference/Highcharts.Series.html#data,
- * and https://github.com/highcharts/highcharts/issues/11116.
- * This can create issues when iterating over the data (using Array.filter() or Array.map() methods is safe, but index access or Array.find()
- * can cause a crash if accessing point's properties without checking).
+ * Returns the series data points, filtering out undefined/destroyed entries.
+ *
+ * @warning **Never access `series.data` directly.** Highcharts' `cropThreshold` optimization
+ * (default: 300 for line, 50 for column/bar) makes `series.data` a sparse array when the dataset
+ * exceeds the threshold and axis extremes are narrower than the full data range. Elements before
+ * `cropStart` are left as `undefined`, causing crashes on property access (e.g., `.find(d => d.x)`).
+ *
+ * The `SafeSeries` type omits `.data` to enforce this at compile time. If you see a cast to
+ * `Series` to access `.data`, it is almost certainly a bug — use this function instead.
+ *
+ * See: https://api.highcharts.com/highcharts/plotOptions.series.cropThreshold
  */
 export const getSeriesData = (series: SafeSeries, options: { includeHiddenPoints?: boolean } = {}): Array<Point> => {
+  // eslint-disable-next-line no-restricted-syntax -- This is the safe wrapper itself.
   return (series as Series).data.filter((p) => (options.includeHiddenPoints ? isPointValid(p) : isPointVisible(p)));
 };


### PR DESCRIPTION
### Description

 Adds documentation and tooling to prevent direct `series.data` access, which is unsafe due to Highcharts' `cropThreshold` sparse array behavior.

  Changes:

  - Enhanced `getSeriesData()` JSDoc with cropThreshold explanation
  - Added ESLint no-restricted-syntax rule flagging `(x as Series).data` casts
  - Added "Highcharts pitfalls" section to CONTRIBUTING.md
  - Referenced pitfalls in AGENTS.md

Related links, issue #, if available: Action item: `3151368`

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
