### PR TITLE
fix: return focus to legend item on Tab when tooltip is visible

### DIFF
--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -6,6 +6,7 @@ import clsx from "clsx";
 
 import {
   circleIndex,
+  getAllFocusables,
   handleKey,
   KeyCode,
   SingleTabStopNavigationAPI,
@@ -27,18 +28,6 @@ const TOOLTIP_SHOW_DELAY = 300;
 const TOOLTIP_BLUR_DELAY = 50;
 const HIGHLIGHT_LOST_DELAY = 50;
 const SCROLL_DELAY = 100;
-
-function focusStaysInTooltipScope(
-  next: EventTarget | null,
-  tooltipEl: HTMLElement | null,
-  triggerEl: HTMLElement | undefined,
-): boolean {
-  if (!next) {
-    return false;
-  }
-  const node = next as Node;
-  return !!(tooltipEl?.contains(node) || triggerEl?.contains(node));
-}
 
 export type LegendAlignment = "horizontal" | "vertical";
 export type LegendHorizontalAlignment = "start" | "center" | "end";
@@ -82,7 +71,7 @@ export const ChartLegend = ({
   const elementsByIndexRef = useRef<Record<number, HTMLElement>>([]);
   const elementsByIdRef = useRef<Record<string, HTMLElement>>({});
   const tooltipRef = useRef<HTMLElement>(null);
-  const tabTrapRef = useRef<HTMLDivElement>(null);
+  const tooltipWrapperRef = useRef<HTMLDivElement>(null);
   const highlightControl = useMemo(() => new DebouncedCall(), []);
   const scrollIntoViewControl = useMemo(() => new DebouncedCall(), []);
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
@@ -117,15 +106,6 @@ export const ChartLegend = ({
       document.removeEventListener("keydown", onDocumentKeyDown, true);
     };
   }, [tooltipItemId, hideTooltip]);
-
-  // Workaround: PopoverBody auto-focuses the dismiss button on mount.
-  // We re-focus the legend trigger here, relying on React's child-before-parent effect ordering.
-  // Remove this once InternalChartTooltip supports a `disableAutoFocus` prop.
-  useEffect(() => {
-    if (tooltipItemId) {
-      elementsByIdRef.current[tooltipItemId]?.focus({ preventScroll: true });
-    }
-  }, [tooltipItemId]);
 
   const isMouseInContainer = useRef<boolean>(false);
 
@@ -170,12 +150,10 @@ export const ChartLegend = ({
   function onBlur(event: React.FocusEvent) {
     navigationAPI.current!.updateFocusTarget();
 
-    // Hide tooltip and clear highlight unless focus moves inside tooltip or to the tab trap;
+    // Hide tooltip and clear highlight unless focus moves inside the tooltip wrapper
+    // (which contains the tooltip itself and its entry/exit tab traps).
     const next = event.relatedTarget as Node | null;
-    if (next && tooltipRef.current?.contains(next)) {
-      return;
-    }
-    if (next && tabTrapRef.current?.contains(next)) {
+    if (next && tooltipWrapperRef.current?.contains(next)) {
       return;
     }
     if (next) {
@@ -338,47 +316,44 @@ export const ChartLegend = ({
         </div>
       </SingleTabStopNavigationProvider>
       {tooltipContent && (
-        <div
-          ref={tabTrapRef}
-          tabIndex={0}
-          onFocus={() => tooltipRef.current?.querySelector<HTMLElement>("button")?.focus()}
-          style={{ position: "absolute", width: 0, height: 0, overflow: "hidden" }}
-        />
-      )}
-      {tooltipContent && (
-        <InternalChartTooltip
-          ref={tooltipRef}
-          trackRef={tooltipTrack}
-          triggerClampRef={containerRef}
-          trackKey={tooltipTarget.id}
-          container={null}
-          dismissButton={true}
-          onDismiss={() => {
-            hideTooltip(true);
-            elementsByIdRef.current[tooltipTarget.id]?.focus();
-          }}
-          position={tooltipPosition}
-          title={tooltipContent.header}
-          onMouseEnter={() => showTooltip(tooltipTarget.id)}
-          onMouseLeave={() => hideTooltip()}
-          onBlur={(event) => {
-            const trigger = elementsByIdRef.current[tooltipTarget.id];
-            if (focusStaysInTooltipScope(event.relatedTarget, tooltipRef.current, trigger)) {
-              return;
+        <div ref={tooltipWrapperRef}>
+          {/* [1] skips FocusLock's leading TabTrap to target the dismiss button. */}
+          <div tabIndex={0} onFocus={() => tooltipRef.current && getAllFocusables(tooltipRef.current)[1]?.focus()} />
+          <InternalChartTooltip
+            ref={tooltipRef}
+            trackRef={tooltipTrack}
+            triggerClampRef={containerRef}
+            trackKey={tooltipTarget.id}
+            container={null}
+            dismissButton={true}
+            disableDismissAutoFocus={true}
+            onDismiss={() => {
+              hideTooltip(true);
+              elementsByIdRef.current[tooltipTarget.id]?.focus();
+            }}
+            position={tooltipPosition}
+            title={tooltipContent.header}
+            onMouseEnter={() => showTooltip(tooltipTarget.id)}
+            onMouseLeave={() => hideTooltip()}
+            onBlur={(event) => {
+              if (tooltipWrapperRef.current?.contains(event.relatedTarget as Node)) {
+                return;
+              }
+              hideTooltip();
+            }}
+            footer={
+              tooltipContent.footer && (
+                <>
+                  <hr aria-hidden={true} />
+                  {tooltipContent.footer}
+                </>
+              )
             }
-            hideTooltip();
-          }}
-          footer={
-            tooltipContent.footer && (
-              <>
-                <hr aria-hidden={true} />
-                {tooltipContent.footer}
-              </>
-            )
-          }
-        >
-          {tooltipContent.body}
-        </InternalChartTooltip>
+          >
+            {tooltipContent.body}
+          </InternalChartTooltip>
+          <div tabIndex={0} onFocus={() => tooltipRef.current && getAllFocusables(tooltipRef.current)[1]?.focus()} />
+        </div>
       )}
     </div>
   );

--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -6,7 +6,6 @@ import clsx from "clsx";
 
 import {
   circleIndex,
-  getAllFocusables,
   handleKey,
   KeyCode,
   SingleTabStopNavigationAPI,
@@ -71,7 +70,6 @@ export const ChartLegend = ({
   const elementsByIndexRef = useRef<Record<number, HTMLElement>>([]);
   const elementsByIdRef = useRef<Record<string, HTMLElement>>({});
   const tooltipRef = useRef<HTMLElement>(null);
-  const tooltipWrapperRef = useRef<HTMLDivElement>(null);
   const highlightControl = useMemo(() => new DebouncedCall(), []);
   const scrollIntoViewControl = useMemo(() => new DebouncedCall(), []);
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
@@ -150,10 +148,9 @@ export const ChartLegend = ({
   function onBlur(event: React.FocusEvent) {
     navigationAPI.current!.updateFocusTarget();
 
-    // Hide tooltip and clear highlight unless focus moves inside the tooltip wrapper
-    // (which contains the tooltip itself and its entry/exit tab traps).
+    // Hide tooltip and clear highlight unless focus moves inside the tooltip.
     const next = event.relatedTarget as Node | null;
-    if (next && tooltipWrapperRef.current?.contains(next)) {
+    if (next && tooltipRef.current?.contains(next)) {
       return;
     }
     if (next) {
@@ -316,38 +313,33 @@ export const ChartLegend = ({
         </div>
       </SingleTabStopNavigationProvider>
       {tooltipContent && (
-        <div ref={tooltipWrapperRef}>
-          {/* [1] skips FocusLock's leading TabTrap to target the dismiss button. */}
-          <div tabIndex={0} onFocus={() => tooltipRef.current && getAllFocusables(tooltipRef.current)[1]?.focus()} />
-          <InternalChartTooltip
-            ref={tooltipRef}
-            trackRef={tooltipTrack}
-            triggerClampRef={containerRef}
-            trackKey={tooltipTarget.id}
-            container={null}
-            dismissButton={true}
-            disableDismissAutoFocus={true}
-            onDismiss={() => {
-              hideTooltip(true);
-              elementsByIdRef.current[tooltipTarget.id]?.focus();
-            }}
-            position={tooltipPosition}
-            title={tooltipContent.header}
-            onMouseEnter={() => showTooltip(tooltipTarget.id)}
-            onMouseLeave={() => hideTooltip()}
-            footer={
-              tooltipContent.footer && (
-                <>
-                  <hr aria-hidden={true} />
-                  {tooltipContent.footer}
-                </>
-              )
-            }
-          >
-            {tooltipContent.body}
-          </InternalChartTooltip>
-          <div tabIndex={0} onFocus={() => tooltipRef.current && getAllFocusables(tooltipRef.current)[1]?.focus()} />
-        </div>
+        <InternalChartTooltip
+          ref={tooltipRef}
+          trackRef={tooltipTrack}
+          triggerClampRef={containerRef}
+          trackKey={tooltipTarget.id}
+          container={null}
+          dismissButton={true}
+          disableDismissAutoFocus={true}
+          onDismiss={() => {
+            hideTooltip(true);
+            elementsByIdRef.current[tooltipTarget.id]?.focus();
+          }}
+          position={tooltipPosition}
+          title={tooltipContent.header}
+          onMouseEnter={() => showTooltip(tooltipTarget.id)}
+          onMouseLeave={() => hideTooltip()}
+          footer={
+            tooltipContent.footer && (
+              <>
+                <hr aria-hidden={true} />
+                {tooltipContent.footer}
+              </>
+            )
+          }
+        >
+          {tooltipContent.body}
+        </InternalChartTooltip>
       )}
     </div>
   );

--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -6,7 +6,6 @@ import clsx from "clsx";
 
 import {
   circleIndex,
-  getAllFocusables,
   handleKey,
   KeyCode,
   SingleTabStopNavigationAPI,
@@ -28,20 +27,6 @@ const TOOLTIP_SHOW_DELAY = 300;
 const TOOLTIP_BLUR_DELAY = 50;
 const HIGHLIGHT_LOST_DELAY = 50;
 const SCROLL_DELAY = 100;
-
-// Selector for "real" interactive elements inside the popover. Skips the popover's
-// internal TabTrap helpers (rendered as <div tabindex="0">) so Tab from the trigger
-// lands on the dismiss button or the first content control.
-const TOOLTIP_INTERACTIVE_SELECTOR = "button, a[href], input, select, textarea";
-
-function focusFirstInteractiveInTooltip(tooltipEl: HTMLElement): boolean {
-  const first = getAllFocusables(tooltipEl).find((el) => el.matches(TOOLTIP_INTERACTIVE_SELECTOR));
-  if (first) {
-    first.focus();
-    return true;
-  }
-  return false;
-}
 
 function focusStaysInTooltipScope(
   next: EventTarget | null,
@@ -97,19 +82,16 @@ export const ChartLegend = ({
   const elementsByIndexRef = useRef<Record<number, HTMLElement>>([]);
   const elementsByIdRef = useRef<Record<string, HTMLElement>>({});
   const tooltipRef = useRef<HTMLElement>(null);
+  const tabTrapRef = useRef<HTMLDivElement>(null);
   const highlightControl = useMemo(() => new DebouncedCall(), []);
   const scrollIntoViewControl = useMemo(() => new DebouncedCall(), []);
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const [tooltipItemId, setTooltipItemId] = useState<string | null>(null);
-  const [dismissButtonVisible, setDismissButtonVisible] = useState<boolean>(false);
   const { showTooltip, hideTooltip } = useMemo(() => {
     const control = new DebouncedCall();
     return {
-      showTooltip(itemId: string, mode: "keyboard" | "mouse") {
-        control.call(() => {
-          setTooltipItemId(itemId);
-          setDismissButtonVisible(mode === "keyboard");
-        }, TOOLTIP_SHOW_DELAY);
+      showTooltip(itemId: string) {
+        control.call(() => setTooltipItemId(itemId), TOOLTIP_SHOW_DELAY);
       },
       hideTooltip(lock = false) {
         control.call(() => setTooltipItemId(null), TOOLTIP_BLUR_DELAY);
@@ -136,11 +118,14 @@ export const ChartLegend = ({
     };
   }, [tooltipItemId, hideTooltip]);
 
+  // Workaround: PopoverBody auto-focuses the dismiss button on mount.
+  // We re-focus the legend trigger here, relying on React's child-before-parent effect ordering.
+  // Remove this once InternalChartTooltip supports a `disableAutoFocus` prop.
   useEffect(() => {
-    if (tooltipItemId && dismissButtonVisible) {
+    if (tooltipItemId) {
       elementsByIdRef.current[tooltipItemId]?.focus({ preventScroll: true });
     }
-  }, [tooltipItemId, dismissButtonVisible]);
+  }, [tooltipItemId]);
 
   const isMouseInContainer = useRef<boolean>(false);
 
@@ -179,14 +164,21 @@ export const ChartLegend = ({
     setSelectedIndex(index);
     navigationAPI.current!.updateFocusTarget();
     showHighlight(itemId);
-    showTooltip(itemId, "keyboard");
+    showTooltip(itemId);
   }
 
   function onBlur(event: React.FocusEvent) {
     navigationAPI.current!.updateFocusTarget();
 
-    // Hide tooltip and clear highlight unless focus moves inside tooltip;
-    if (tooltipRef.current && event.relatedTarget && !tooltipRef.current.contains(event.relatedTarget)) {
+    // Hide tooltip and clear highlight unless focus moves inside tooltip or to the tab trap;
+    const next = event.relatedTarget as Node | null;
+    if (next && tooltipRef.current?.contains(next)) {
+      return;
+    }
+    if (next && tabTrapRef.current?.contains(next)) {
+      return;
+    }
+    if (next) {
       clearHighlight();
       hideTooltip();
     }
@@ -197,12 +189,6 @@ export const ChartLegend = ({
   }
 
   function onKeyDown(event: React.KeyboardEvent<HTMLElement>) {
-    if (event.keyCode === KeyCode.tab && !event.shiftKey && tooltipRef.current) {
-      if (focusFirstInteractiveInTooltip(tooltipRef.current)) {
-        event.preventDefault();
-        return;
-      }
-    }
     if (
       event.keyCode === KeyCode.right ||
       event.keyCode === KeyCode.left ||
@@ -305,7 +291,7 @@ export const ChartLegend = ({
             const handlers = {
               onMouseEnter: () => {
                 showHighlight(item.id);
-                showTooltip(item.id, "mouse");
+                showTooltip(item.id);
               },
               onMouseLeave: () => {
                 clearHighlight();
@@ -352,20 +338,28 @@ export const ChartLegend = ({
         </div>
       </SingleTabStopNavigationProvider>
       {tooltipContent && (
+        <div
+          ref={tabTrapRef}
+          tabIndex={0}
+          onFocus={() => tooltipRef.current?.querySelector<HTMLElement>("button")?.focus()}
+          style={{ position: "absolute", width: 0, height: 0, overflow: "hidden" }}
+        />
+      )}
+      {tooltipContent && (
         <InternalChartTooltip
           ref={tooltipRef}
           trackRef={tooltipTrack}
           triggerClampRef={containerRef}
           trackKey={tooltipTarget.id}
           container={null}
-          dismissButton={dismissButtonVisible}
+          dismissButton={true}
           onDismiss={() => {
             hideTooltip(true);
             elementsByIdRef.current[tooltipTarget.id]?.focus();
           }}
           position={tooltipPosition}
           title={tooltipContent.header}
-          onMouseEnter={() => showTooltip(tooltipTarget.id, dismissButtonVisible ? "keyboard" : "mouse")}
+          onMouseEnter={() => showTooltip(tooltipTarget.id)}
           onMouseLeave={() => hideTooltip()}
           onBlur={(event) => {
             const trigger = elementsByIdRef.current[tooltipTarget.id];

--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -6,6 +6,7 @@ import clsx from "clsx";
 
 import {
   circleIndex,
+  getAllFocusables,
   handleKey,
   KeyCode,
   SingleTabStopNavigationAPI,
@@ -27,6 +28,32 @@ const TOOLTIP_SHOW_DELAY = 300;
 const TOOLTIP_BLUR_DELAY = 50;
 const HIGHLIGHT_LOST_DELAY = 50;
 const SCROLL_DELAY = 100;
+
+// Selector for "real" interactive elements inside the popover. Skips the popover's
+// internal TabTrap helpers (rendered as <div tabindex="0">) so Tab from the trigger
+// lands on the dismiss button or the first content control.
+const TOOLTIP_INTERACTIVE_SELECTOR = "button, a[href], input, select, textarea";
+
+function focusFirstInteractiveInTooltip(tooltipEl: HTMLElement): boolean {
+  const first = getAllFocusables(tooltipEl).find((el) => el.matches(TOOLTIP_INTERACTIVE_SELECTOR));
+  if (first) {
+    first.focus();
+    return true;
+  }
+  return false;
+}
+
+function focusStaysInTooltipScope(
+  next: EventTarget | null,
+  tooltipEl: HTMLElement | null,
+  triggerEl: HTMLElement | undefined,
+): boolean {
+  if (!next) {
+    return false;
+  }
+  const node = next as Node;
+  return !!(tooltipEl?.contains(node) || triggerEl?.contains(node));
+}
 
 export type LegendAlignment = "horizontal" | "vertical";
 export type LegendHorizontalAlignment = "start" | "center" | "end";
@@ -74,11 +101,15 @@ export const ChartLegend = ({
   const scrollIntoViewControl = useMemo(() => new DebouncedCall(), []);
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const [tooltipItemId, setTooltipItemId] = useState<string | null>(null);
+  const [dismissButtonVisible, setDismissButtonVisible] = useState<boolean>(false);
   const { showTooltip, hideTooltip } = useMemo(() => {
     const control = new DebouncedCall();
     return {
-      showTooltip(itemId: string) {
-        control.call(() => setTooltipItemId(itemId), TOOLTIP_SHOW_DELAY);
+      showTooltip(itemId: string, mode: "keyboard" | "mouse") {
+        control.call(() => {
+          setTooltipItemId(itemId);
+          setDismissButtonVisible(mode === "keyboard");
+        }, TOOLTIP_SHOW_DELAY);
       },
       hideTooltip(lock = false) {
         control.call(() => setTooltipItemId(null), TOOLTIP_BLUR_DELAY);
@@ -98,17 +129,19 @@ export const ChartLegend = ({
         hideTooltip(true);
         elementsByIdRef.current[tooltipItemId]?.focus();
       }
-      if (event.keyCode === KeyCode.tab) {
-        event.preventDefault();
-        hideTooltip(true);
-        elementsByIdRef.current[tooltipItemId]?.focus();
-      }
     };
     document.addEventListener("keydown", onDocumentKeyDown, true);
     return () => {
       document.removeEventListener("keydown", onDocumentKeyDown, true);
     };
-  }, [items, tooltipItemId, hideTooltip]);
+  }, [tooltipItemId, hideTooltip]);
+
+  useEffect(() => {
+    if (tooltipItemId && dismissButtonVisible) {
+      elementsByIdRef.current[tooltipItemId]?.focus({ preventScroll: true });
+    }
+  }, [tooltipItemId, dismissButtonVisible]);
+
   const isMouseInContainer = useRef<boolean>(false);
 
   // Scrolling to the highlighted legend item.
@@ -146,7 +179,7 @@ export const ChartLegend = ({
     setSelectedIndex(index);
     navigationAPI.current!.updateFocusTarget();
     showHighlight(itemId);
-    showTooltip(itemId);
+    showTooltip(itemId, "keyboard");
   }
 
   function onBlur(event: React.FocusEvent) {
@@ -164,6 +197,12 @@ export const ChartLegend = ({
   }
 
   function onKeyDown(event: React.KeyboardEvent<HTMLElement>) {
+    if (event.keyCode === KeyCode.tab && !event.shiftKey && tooltipRef.current) {
+      if (focusFirstInteractiveInTooltip(tooltipRef.current)) {
+        event.preventDefault();
+        return;
+      }
+    }
     if (
       event.keyCode === KeyCode.right ||
       event.keyCode === KeyCode.left ||
@@ -222,25 +261,25 @@ export const ChartLegend = ({
   const tooltipPosition = isVertical ? "left" : "bottom";
 
   return (
-    <SingleTabStopNavigationProvider
-      ref={navigationAPI}
-      navigationActive={true}
-      getNextFocusTarget={() => getNextFocusTarget()}
-      onUnregisterActive={(element: HTMLElement) => onUnregisterActive(element, navigationAPI)}
+    <div
+      role="toolbar"
+      aria-label={legendTitle || ariaLabel}
+      className={clsx(testClasses.root, styles.root, className)}
+      data-axisid={axisId}
+      onMouseEnter={() => (isMouseInContainer.current = true)}
+      onMouseLeave={() => (isMouseInContainer.current = false)}
     >
-      <div
-        role="toolbar"
-        aria-label={legendTitle || ariaLabel}
-        className={clsx(testClasses.root, styles.root, className)}
-        data-axisid={axisId}
-        onMouseEnter={() => (isMouseInContainer.current = true)}
-        onMouseLeave={() => (isMouseInContainer.current = false)}
+      {legendTitle && (
+        <Box fontWeight="bold" className={testClasses.title} textAlign={getBoxTextAlignment(horizontalAlignment)}>
+          {legendTitle}
+        </Box>
+      )}
+      <SingleTabStopNavigationProvider
+        ref={navigationAPI}
+        navigationActive={true}
+        getNextFocusTarget={() => getNextFocusTarget()}
+        onUnregisterActive={(element: HTMLElement) => onUnregisterActive(element, navigationAPI)}
       >
-        {legendTitle && (
-          <Box fontWeight="bold" className={testClasses.title} textAlign={getBoxTextAlignment(horizontalAlignment)}>
-            {legendTitle}
-          </Box>
-        )}
         <div
           // The list element is not focusable. However, the focus lands on it regardless, when testing in Firefox.
           // Setting the tab index to -1 does fix the problem.
@@ -266,7 +305,7 @@ export const ChartLegend = ({
             const handlers = {
               onMouseEnter: () => {
                 showHighlight(item.id);
-                showTooltip(item.id);
+                showTooltip(item.id, "mouse");
               },
               onMouseLeave: () => {
                 clearHighlight();
@@ -311,33 +350,43 @@ export const ChartLegend = ({
             );
           })}
         </div>
-        {tooltipContent && (
-          <InternalChartTooltip
-            trackRef={tooltipTrack}
-            triggerClampRef={containerRef}
-            trackKey={tooltipTarget.id}
-            container={null}
-            dismissButton={false}
-            onDismiss={() => {}}
-            position={tooltipPosition}
-            title={tooltipContent.header}
-            onMouseEnter={() => showTooltip(tooltipTarget.id)}
-            onMouseLeave={() => hideTooltip()}
-            onBlur={() => hideTooltip()}
-            footer={
-              tooltipContent.footer && (
-                <>
-                  <hr aria-hidden={true} />
-                  {tooltipContent.footer}
-                </>
-              )
+      </SingleTabStopNavigationProvider>
+      {tooltipContent && (
+        <InternalChartTooltip
+          ref={tooltipRef}
+          trackRef={tooltipTrack}
+          triggerClampRef={containerRef}
+          trackKey={tooltipTarget.id}
+          container={null}
+          dismissButton={dismissButtonVisible}
+          onDismiss={() => {
+            hideTooltip(true);
+            elementsByIdRef.current[tooltipTarget.id]?.focus();
+          }}
+          position={tooltipPosition}
+          title={tooltipContent.header}
+          onMouseEnter={() => showTooltip(tooltipTarget.id, dismissButtonVisible ? "keyboard" : "mouse")}
+          onMouseLeave={() => hideTooltip()}
+          onBlur={(event) => {
+            const trigger = elementsByIdRef.current[tooltipTarget.id];
+            if (focusStaysInTooltipScope(event.relatedTarget, tooltipRef.current, trigger)) {
+              return;
             }
-          >
-            {tooltipContent.body}
-          </InternalChartTooltip>
-        )}
-      </div>
-    </SingleTabStopNavigationProvider>
+            hideTooltip();
+          }}
+          footer={
+            tooltipContent.footer && (
+              <>
+                <hr aria-hidden={true} />
+                {tooltipContent.footer}
+              </>
+            )
+          }
+        >
+          {tooltipContent.body}
+        </InternalChartTooltip>
+      )}
+    </div>
   );
 };
 

--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -335,12 +335,6 @@ export const ChartLegend = ({
             title={tooltipContent.header}
             onMouseEnter={() => showTooltip(tooltipTarget.id)}
             onMouseLeave={() => hideTooltip()}
-            onBlur={(event) => {
-              if (tooltipWrapperRef.current?.contains(event.relatedTarget as Node)) {
-                return;
-              }
-              hideTooltip();
-            }}
             footer={
               tooltipContent.footer && (
                 <>

--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -98,6 +98,11 @@ export const ChartLegend = ({
         hideTooltip(true);
         elementsByIdRef.current[tooltipItemId]?.focus();
       }
+      if (event.keyCode === KeyCode.tab) {
+        event.preventDefault();
+        hideTooltip(true);
+        elementsByIdRef.current[tooltipItemId]?.focus();
+      }
     };
     document.addEventListener("keydown", onDocumentKeyDown, true);
     return () => {


### PR DESCRIPTION
### Description

When a chart legend tooltip is visible and the user presses Tab, focus falls to `<body>` instead of returning to the legend item that triggered the tooltip. This is a WCAG 2.4.3 (Focus Order) violation.

This revision implements the approach suggested in review: an unconditional dismiss button with the tooltip's built-in FocusLock handling focus entry/cycling, rather than capturing Tab keypresses or using custom tab traps.

#### Changes

**1. Unconditional dismiss button.**

The tooltip now always renders a dismiss (X) button — both on hover and on keyboard focus. This engages the popover's built-in FocusLock unconditionally, so Tab always cycles through the tooltip's interactive content. Activating the dismiss button (Enter/Space) closes the tooltip and returns focus to the legend item.

**2. Built-in FocusLock handles focus entry.**

The tooltip's FocusLock (updated in [cloudscape-design/components#4518](https://github.com/cloudscape-design/components/pull/4518)) now correctly routes focus to the first interactive element when entering from outside. This eliminates the need for custom tab trap elements — the tooltip's built-in TabTraps handle both entry and cycling natively.

**3. Tightened `<SingleTabStopNavigationProvider>` scope.**

Previously, `<SingleTabStopNavigationProvider>` wrapped both the legend item list AND the tooltip. Because Cloudscape's `Button`, `Link`, and other interactive components consume `useSingleTabStopNavigation` from the context, every focusable element inside the tooltip received `tabindex="-1"` — making them keyboard-unreachable.

The provider now wraps only the legend item list:

```tsx
<div role="toolbar">
  <SingleTabStopNavigationProvider>
    {legend items}
  </SingleTabStopNavigationProvider>
  {tooltip}
</div>
```

This aligns with the pattern used by Cloudscape's other navigable components — Tabs (`tab-header-bar.tsx`), NavigableGroup, TreeView, and Table all scope `<SingleTabStopNavigationProvider>` to the navigable region only.

#### Behavior

| Action | Result |
|---|---|
| Hover legend item | Tooltip appears with dismiss button |
| Tab to legend item | Tooltip appears with dismiss button; focus stays on legend item |
| Tab again | Focus enters tooltip via built-in FocusLock (lands on dismiss button) |
| Tab | Cycles through tooltip's interactive content |
| Enter/Space on dismiss | Tooltip closes, focus returns to the legend item |
| Escape | Tooltip closes, focus returns to the legend item |
| Arrow keys on legend | Move between legend items; tooltip follows |

#### Implementation note

Uses `disableDismissAutoFocus={true}` (added in [cloudscape-design/components#4510](https://github.com/cloudscape-design/components/pull/4510)) to prevent the tooltip's built-in FocusLock from stealing focus from the legend item on mount.

Relies on the FocusLock direction fix ([cloudscape-design/components#4518](https://github.com/cloudscape-design/components/pull/4518)) which makes the leading TabTrap call `focusFirst()` when focus enters from outside (previously it always called `focusLast()`). This is what allows us to remove the custom tab traps entirely.

Related links, issue #, if available: Blocking accessibility compliance reports (ACRs):
- [License Manager - 2144904697](https://amp.aws.levelaccess.net/public/reporting/view_instance.php?instance_id=2144904697)
- [License Manager - 2144904699](https://amp.aws.levelaccess.net/public/reporting/view_instance.php?instance_id=2144904699)

### How has this been tested?

- Manually tested in CloudWatch Console on the pages where the issue was originally reported.
- Manually tested in `chart-components`'s own dev pages (`pages/03-core/core-legend.page.tsx`) using `npm start`.
- Verified: Tab on legend item → tooltip appears with dismiss button → Tab → focus enters tooltip (dismiss button) → Tab cycles through interactive content.
- Verified: Activating dismiss button closes tooltip and returns focus to legend item.
- Verified: Escape closes tooltip and returns focus to legend item.
- Verified: Arrow key navigation between legend items still works.
- Verified: Mouse hover shows tooltip with dismiss button (unconditional).
- Verified: Tooltip content elements no longer have `tabindex="-1"` after provider restructure.
- Verified: No custom tab traps needed — tooltip's built-in FocusLock handles entry correctly after #4518.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A — no public API change.
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._ ✓ Backward-compatible. Tooltip interactive content is now keyboard-reachable — a strict accessibility improvement.
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._ ✓ Uses existing toolkit utilities (`KeyCode`, `SingleTabStopNavigationProvider`).
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ ✓ Tested with keyboard-only navigation in both Cloudscape's dev environment and CloudWatch Console.

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A — no URL handling.

#### Testing

- _Changes are covered with new/existing unit tests?_ Existing tests cover the Escape path.
- _Changes are covered with new/existing integration tests?_ Manually tested in both CloudWatch Console and `chart-components`'s `npm start` dev environment.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
