### PR TITLE
fix: optimises initial chart rendering when using bottom legend

### DIFF
--- a/pages/01-cartesian-chart/many-series.page.tsx
+++ b/pages/01-cartesian-chart/many-series.page.tsx
@@ -18,6 +18,7 @@ export default function () {
       settings={
         <PageSettingsForm
           selectedSettings={[
+            "containerHeight",
             "verticalAxisTitlePlacement",
             "showLegend",
             "showLegendTitle",
@@ -102,22 +103,25 @@ series.push({ type: "x-threshold", name: "X Threshold", value: 1601000100000 });
 series.push({ type: "y-threshold", name: "Y Threshold", value: 1_500_000 });
 
 function Component() {
-  const { chartProps } = useChartSettings();
+  const { chartProps, settings } = useChartSettings();
   return (
-    <CartesianChart
-      {...chartProps.cartesian}
-      stacking="normal"
-      chartHeight={400}
-      ariaLabel="Area chart"
-      series={series}
-      xAxis={{
-        type: "datetime",
-        title: "Time (UTC)",
-        min: domain[0].getTime(),
-        max: domain[domain.length - 1].getTime(),
-        valueFormatter: dateFormatter,
-      }}
-      yAxis={{ title: "Bytes transferred" }}
-    />
+    <div style={{ height: settings.containerHeight }}>
+      <CartesianChart
+        {...chartProps.cartesian}
+        fitHeight={true}
+        stacking="normal"
+        chartHeight={400}
+        ariaLabel="Area chart"
+        series={series}
+        xAxis={{
+          type: "datetime",
+          title: "Time (UTC)",
+          min: domain[0].getTime(),
+          max: domain[domain.length - 1].getTime(),
+          valueFormatter: dateFormatter,
+        }}
+        yAxis={{ title: "Bytes transferred" }}
+      />
+    </div>
   );
 }

--- a/src/core/__tests__/chart-core-fit-size.test.tsx
+++ b/src/core/__tests__/chart-core-fit-size.test.tsx
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useRef } from "react";
-import { waitFor } from "@testing-library/react";
+import { render as rtlRender, waitFor } from "@testing-library/react";
 import highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 import { vi } from "vitest";
 
 import { circleIndex } from "@cloudscape-design/component-toolkit/internal";
 
+import { ChartContainer } from "../../../lib/components/core/chart-container";
 import testClasses from "../../../lib/components/core/test-classes/styles.selectors";
 import { objectContainingDeep, renderChart } from "./common";
 
@@ -29,7 +30,7 @@ vi.mock("@cloudscape-design/component-toolkit/internal", async () => {
       useEffect(() => {
         cb({ contentBoxHeight: mockSizes[index] });
         // eslint-disable-next-line react-hooks/exhaustive-deps
-      }, []);
+      }, [mockSizes[index]]);
     },
   };
 });
@@ -144,5 +145,62 @@ describe("CoreChart: fit-size", () => {
     rerender({ highcharts, fitHeight, chartMinWidth: 333 });
 
     expect(wrapper.findByClassName(testClasses["chart-plot-wrapper"])!.getElement().style.minInlineSize).toBe("333px");
+  });
+
+  test("hides chart plot wrapper while waiting for footer measurement with fitHeight and bottom legend", async () => {
+    // Hidden when fitHeight + bottom legend + footer not yet measured
+    mockSizes[0] = 100;
+    mockSizes[1] = 0;
+    mockSizes[2] = 0;
+    queryMeasurementIndex = 0;
+
+    const { container, rerender } = rtlRender(
+      <ChartContainer
+        chart={() => <div>chart</div>}
+        verticalAxisTitlePlacement="side"
+        legendPosition="bottom"
+        fitHeight={true}
+        primaryLegend={<div>Legend</div>}
+      />,
+    );
+
+    await waitFor(() => {
+      const plotWrapper = container.querySelector(`.${testClasses["chart-plot-wrapper"]}`);
+      expect(plotWrapper!.style.visibility).toBe("hidden");
+    });
+
+    // Visible once footer is measured
+    mockSizes[2] = 20;
+    rerender(
+      <ChartContainer
+        chart={() => <div>chart</div>}
+        verticalAxisTitlePlacement="side"
+        legendPosition="bottom"
+        fitHeight={true}
+        primaryLegend={<div>Legend</div>}
+      />,
+    );
+
+    await waitFor(() => {
+      const plotWrapper = container.querySelector(`.${testClasses["chart-plot-wrapper"]}`);
+      expect(plotWrapper!.style.visibility).toBe("");
+    });
+
+    // Visible with side legend even when footer not measured
+    mockSizes[2] = 0;
+    rerender(
+      <ChartContainer
+        chart={() => <div>chart</div>}
+        verticalAxisTitlePlacement="side"
+        legendPosition="side"
+        fitHeight={true}
+        primaryLegend={<div>Legend</div>}
+      />,
+    );
+
+    await waitFor(() => {
+      const plotWrapper = container.querySelector(`.${testClasses["chart-plot-wrapper"]}`);
+      expect(plotWrapper!.style.visibility).toBe("");
+    });
   });
 });

--- a/src/core/chart-container.tsx
+++ b/src/core/chart-container.tsx
@@ -68,7 +68,7 @@ export function ChartContainer({
   const withMinHeight = (height: number) => Math.max(chartMinHeight ?? DEFAULT_CHART_MIN_HEIGHT, height) - heightOffset;
   const measuredChartHeight = withMinHeight(measures.chart - measures.header - measures.footer);
   const effectiveChartHeight = fitHeight ? measuredChartHeight : withMinHeight(chartHeight ?? DEFAULT_CHART_HEIGHT);
-  const hasLegend = primaryLegend || secondaryLegend;
+  const hasLegend = !!(primaryLegend || secondaryLegend);
   return (
     <div
       ref={refs.chart}
@@ -99,8 +99,14 @@ export function ChartContainer({
         </div>
       ) : (
         <div
-          style={chartMinWidth !== undefined ? { minInlineSize: chartMinWidth } : {}}
           className={clsx(styles["chart-plot-wrapper"], testClasses["chart-plot-wrapper"])}
+          style={getChartPlotWrapperStyles({
+            measures,
+            fitHeight,
+            hasLegend,
+            chartMinWidth,
+            legendPosition,
+          })}
         >
           {verticalAxisTitle}
           {chart(effectiveChartHeight)}
@@ -125,10 +131,38 @@ export function ChartContainer({
   );
 }
 
+/**
+ * Computes the styles for the chart plot wrapper in the bottom/no-legend layout case.
+ * When fitHeight is enabled with a bottom legend, the chart height depends on the footer measurement.
+ * Without this, the chart briefly renders at full container height then visibly shrinks once the
+ * legend is measured, causing a layout shift. We hide the chart until the footer measurement
+ * completes to prevent this flash.
+ */
+function getChartPlotWrapperStyles({
+  measures,
+  fitHeight,
+  hasLegend,
+  chartMinWidth,
+  legendPosition,
+}: {
+  hasLegend: boolean;
+  fitHeight?: boolean;
+  chartMinWidth?: number;
+  legendPosition: "bottom" | "side";
+  measures: { header: number; footer: number; chart: number };
+}): React.CSSProperties {
+  const needsFooterMeasure =
+    fitHeight && hasLegend && legendPosition !== "side" && measures.footer === 0 && measures.chart > 0;
+  return {
+    ...(needsFooterMeasure && { visibility: "hidden" }),
+    ...(chartMinWidth !== undefined && { minInlineSize: chartMinWidth }),
+  };
+}
+
 // This hook combines 3 resize observer and does a small optimization to batch their updates in a single set-state.
 function useContainerQueries() {
-  const [measuresState, setMeasuresState] = useState({ ready: false, chart: 0, header: 0, footer: 0 });
-  const measuresRef = useRef({ ready: false, chart: 0, header: 0, footer: 0 });
+  const [measuresState, setMeasuresState] = useState({ chart: 0, header: 0, footer: 0 });
+  const measuresRef = useRef({ chart: 0, header: 0, footer: 0 });
   const measureDebounce = useRef(new DebouncedCall()).current;
   const setMeasure = (type: "chart" | "header" | "footer", value: number) => {
     measuresRef.current[type] = value;


### PR DESCRIPTION
When fitHeight is enabled with a bottom legend, the chart must wait for the footer measurement before computing the correct height. Previously the chart would render at full height then visibly shrink once the legend measured in. Now the chart-plot-wrapper is hidden with visibility:hidden until the footer measurement completes.

Also adds a unit test for getChartPlotWrapperStyles and updates the many-series dev page to use fitHeight for easier reproduction.

### Description

Fixes a rendering issue where the chart would display with incorrect height
when fitHeight is enabled with a bottom legend position. The chart now
remains hidden (via CSS visibility) until the footer measurements complete,
preventing visual glitches during the measurement phase.

### How has this been tested?

Tested with page 01-cartesian-chart/many-series with CPU throttling between 6-20 times to see the legend used to cause the chart to resize but now it renders simultaneously.

Also added some basic unit test to help identify breaking changes in future.
         
#### Before

https://github.com/user-attachments/assets/4ec3277c-31f9-4f98-8bec-8d23e5640251

#### After

https://github.com/user-attachments/assets/39c294d2-2713-431c-a515-5e9797daa90d

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.