### PR TITLE
feat: expose per-series fillOpacity on area series

### DIFF
--- a/src/cartesian-chart/__tests__/cartesian-chart-series.test.tsx
+++ b/src/cartesian-chart/__tests__/cartesian-chart-series.test.tsx
@@ -36,6 +36,23 @@ describe("CartesianChart: series", () => {
     }
   });
 
+  test.each(["area", "areaspline"] as const)(
+    "forwards %s series fillOpacity to Highcharts, overriding the default while preserving it otherwise",
+    (type) => {
+      renderCartesianChart({
+        highcharts,
+        series: [
+          { type, name: "Default", data: [{ x: 1, y: 1 }] },
+          { type, name: "Custom", data: [{ x: 1, y: 2 }], fillOpacity: 0.15 },
+        ],
+      });
+      // Default fill opacity (from plotOptions) is kept when the series omits it.
+      expect((hc.getChartSeries(0).options as { fillOpacity?: number }).fillOpacity).toBe(0.4);
+      // Explicit per-series value wins over the default.
+      expect((hc.getChartSeries(1).options as { fillOpacity?: number }).fillOpacity).toBe(0.15);
+    },
+  );
+
   test("renders threshold series only", () => {
     renderCartesianChart({
       highcharts,

--- a/src/cartesian-chart/index.tsx
+++ b/src/cartesian-chart/index.tsx
@@ -78,6 +78,7 @@ function transformSeries(
     switch (s.type) {
       case "area":
       case "areaspline":
+        return transformAreaSeries(s, untransformedSeries);
       case "line":
       case "spline":
         return transformLineLikeSeries(s, untransformedSeries);
@@ -144,6 +145,17 @@ function transformLineLikeSeries<
     ...transformZones(s),
     data,
   } as S;
+}
+
+function transformAreaSeries<
+  S extends CartesianChartProps.AreaSeriesOptions | CartesianChartProps.AreaSplineSeriesOptions,
+>(s: S, allSeries: readonly CartesianChartProps.SeriesOptions[]): null | S {
+  const transformed = transformLineLikeSeries(s, allSeries);
+  // Only forward fillOpacity when set; spreading `undefined` would clear the default fill opacity.
+  if (transformed === null || s.fillOpacity === undefined) {
+    return transformed;
+  }
+  return { ...transformed, fillOpacity: s.fillOpacity } as S;
 }
 
 function transformColumnSeries<S extends CartesianChartProps.ColumnSeriesOptions>(

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -209,11 +209,15 @@ export interface BaseTooltipPointFormatted {
 export interface AreaSeriesOptions extends BaseCartesianLineLikeOptions, LinkableSeries, WithZones {
   type: "area";
   data: readonly PointDataItemType[];
+  /** Opacity of the area fill, from 0 (transparent) to 1 (opaque). Defaults to 0.4. */
+  fillOpacity?: number;
 }
 
 export interface AreaSplineSeriesOptions extends BaseCartesianLineLikeOptions, LinkableSeries, WithZones {
   type: "areaspline";
   data: readonly PointDataItemType[];
+  /** Opacity of the area fill, from 0 (transparent) to 1 (opaque). Defaults to 0.4. */
+  fillOpacity?: number;
 }
 
 export interface ColumnSeriesOptions extends BaseCartesianSeriesOptions, LinkableSeries, WithZones {


### PR DESCRIPTION
## What
Adds an optional `fillOpacity` to `area` and `areaspline` series options on the CartesianChart public API, and forwards it through to Highcharts.

## Why
The area fill opacity is currently hardcoded to `0.4` (`Styles.areaSeries.fillOpacity`, applied at `plotOptions.area*` in chart-core). Consumers had no supported way to override it: `transformLineLikeSeries` rebuilds each line-like series from a fixed
field list, so any per-series `fillOpacity` was silently dropped before it reached Highcharts. The only workaround was a global `Highcharts.setOptions`, which we want to avoid — this exposes it through the public series API instead, consistent with how series colors are already set.

## How
- `core/interfaces.ts`: add `fillOpacity?: number` to `AreaSeriesOptions` and `AreaSplineSeriesOptions`.
- `cartesian-chart/index.tsx`: forward `fillOpacity` in `transformLineLikeSeries` when present (`line`/`spline` unaffected).
- Per-series value overrides the `0.4` default via standard Highcharts precedence (series options beat `plotOptions`); the default is preserved when omitted.

## Testing
- New unit tests in `cartesian-chart-series.test.tsx`: forwarding on `area`,
  forwarding on `areaspline`, and per-series override winning while the `0.4` default is preserved.
- Full cartesian suite passes (63 tests); typecheck clean.