### PR TITLE
chore: Removes dependency on base component types

### DIFF
--- a/src/internal/components/series-details/index.tsx
+++ b/src/internal/components/series-details/index.tsx
@@ -5,10 +5,8 @@ import { forwardRef, memo, ReactNode, useEffect, useRef } from "react";
 import clsx from "clsx";
 
 import { useMergeRefs } from "@cloudscape-design/component-toolkit/internal";
-import { BaseComponentProps } from "@cloudscape-design/components/internal/base-component";
 import { InternalExpandableSection } from "@cloudscape-design/components/internal/do-not-use/expandable-section";
 
-import { getDataAttributes } from "../../base-component/get-data-attributes";
 import { scrollIntoViewNearestContainer } from "../../utils/dom";
 
 import styles from "./styles.css.js";
@@ -37,7 +35,7 @@ export interface ChartSeriesDetailItem extends ChartDetailPair {
 }
 export type ExpandedSeries = Set<string>;
 
-interface ChartSeriesDetailsProps extends BaseComponentProps {
+interface ChartSeriesDetailsProps {
   details: ReadonlyArray<ChartSeriesDetailItem>;
   expandedSeries?: ExpandedSeries;
   setExpandedState?: (seriesTitle: string, state: boolean) => void;
@@ -47,11 +45,9 @@ interface ChartSeriesDetailsProps extends BaseComponentProps {
 export default memo(forwardRef(ChartSeriesDetails));
 
 function ChartSeriesDetails(
-  { details, expandedSeries, setExpandedState, compactList, ...restProps }: ChartSeriesDetailsProps,
+  { details, expandedSeries, setExpandedState, compactList }: ChartSeriesDetailsProps,
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const baseProps = getDataAttributes(restProps);
-  const className = clsx(baseProps.className, styles.root);
   const detailsRef = useRef<HTMLDivElement | null>(null);
   const mergedRef = useMergeRefs(ref, detailsRef);
   const selectedRef = useRef<HTMLDivElement>(null);
@@ -66,7 +62,7 @@ function ChartSeriesDetails(
   }, [selectedIndex]);
 
   return (
-    <div {...baseProps} className={className} ref={mergedRef}>
+    <div className={styles.root} ref={mergedRef}>
       <ul className={clsx(styles.list, compactList && styles.compact)}>
         {details.map(({ key, value, marker, isDimmed, subItems, expandableId, description, highlighted }, index) => (
           <li

--- a/src/internal/components/series-marker/index.tsx
+++ b/src/internal/components/series-marker/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useUniqueId } from "@cloudscape-design/component-toolkit/internal";
-import { BaseComponentProps } from "@cloudscape-design/components/internal/base-component";
 import { colorBorderStatusWarning, colorTextInteractiveDisabled } from "@cloudscape-design/design-tokens";
 
 import { ChartSeriesMarkerStatus } from "./interfaces";
@@ -20,7 +19,7 @@ export type ChartSeriesMarkerType =
   | "triangle-down"
   | "circle";
 
-export interface ChartSeriesMarkerProps extends BaseComponentProps {
+export interface ChartSeriesMarkerProps {
   type: ChartSeriesMarkerType;
   color: string;
   visible?: boolean;


### PR DESCRIPTION
### Description

Required for https://github.com/cloudscape-design/components/pull/4646.

The base component type is not exposed from the components and must not be imported via /internal namespace.

In fact, this type is not even needed - as chart series detail is an internal component and the base component props are not being used by the upstream code. Another component, chart series marker is technically exposed - but the base props were not used by the component itself - and there is no need to support id and className for it.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
