### PR TITLE
revert: "fix: Improved legend vertical alignment"

### DIFF
--- a/src/internal/components/chart-legend/styles.scss
+++ b/src/internal/components/chart-legend/styles.scss
@@ -63,7 +63,6 @@
   @include styles.default-text-style;
 
   display: inline-flex;
-  align-items: center;
   padding-block: 0;
   padding-inline: 0;
   border-block: 0;

--- a/src/internal/components/series-details/styles.scss
+++ b/src/internal/components/series-details/styles.scss
@@ -40,7 +40,6 @@ $font-weight-bold: cs.$font-weight-heading-s;
   > .key {
     @include styles.text-wrapping;
     display: inline-flex;
-    align-items: center;
     color: cs.$color-text-group-label;
   }
 }

--- a/src/internal/components/series-marker/styles.scss
+++ b/src/internal/components/series-marker/styles.scss
@@ -8,13 +8,12 @@
 
 $marker-size: 16px;
 $marker-inline-size: 25px; // marker-inline-size is greater than marker-size, to have space for the (potential) status marker.
+$marker-margin-top: cs.$space-static-xxxs;
 $marker-margin-right: cs.$space-static-xxs;
 
 .marker {
   @include styles.styles-reset;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  margin-block-start: $marker-margin-top;
   border-start-start-radius: 2px;
   border-start-end-radius: 2px;
   border-end-start-radius: 2px;


### PR DESCRIPTION
Reverts cloudscape-design/chart-components#235

Reason: the legend icons are not showing in the Safari