### PR TITLE
fix: vertically center chart legend and tooltip markers

### DIFF
--- a/src/internal/components/chart-legend/styles.scss
+++ b/src/internal/components/chart-legend/styles.scss
@@ -63,6 +63,7 @@
   @include styles.default-text-style;
 
   display: inline-flex;
+  align-items: center;
   padding-block: 0;
   padding-inline: 0;
   border-block: 0;

--- a/src/internal/components/series-details/styles.scss
+++ b/src/internal/components/series-details/styles.scss
@@ -40,6 +40,7 @@ $font-weight-bold: cs.$font-weight-heading-s;
   > .key {
     @include styles.text-wrapping;
     display: inline-flex;
+    align-items: center;
     color: cs.$color-text-group-label;
   }
 }
@@ -101,7 +102,8 @@ $font-weight-bold: cs.$font-weight-heading-s;
 
 .highlight-indicator {
   position: absolute;
-  top: 3px;
+  top: 50%;
+  transform: translateY(-50%);
   left: -6px;
   inline-size: 3px;
   block-size: calc(marker.$marker-size - 2px);

--- a/src/internal/components/series-marker/styles.scss
+++ b/src/internal/components/series-marker/styles.scss
@@ -8,12 +8,10 @@
 
 $marker-size: 16px;
 $marker-inline-size: 25px; // marker-inline-size is greater than marker-size, to have space for the (potential) status marker.
-$marker-margin-top: cs.$space-static-xxxs;
 $marker-margin-right: cs.$space-static-xxs;
 
 .marker {
   @include styles.styles-reset;
-  margin-block-start: $marker-margin-top;
   border-start-start-radius: 2px;
   border-start-end-radius: 2px;
   border-end-start-radius: 2px;


### PR DESCRIPTION
Description

Legend markers weren't vertically centered against their labels, the marker sat a bit high/low
depending on the font.

The marker used a fixed 2px top margin to fake the alignment, which only worked for one font's
metrics. Swapped that for real centering: align-items: center on the legend item, and flex-center the
marker's SVG (also kills the inline-SVG baseline gap). Now it's pure geometry, so it lines up
regardless of font/theme.

### How has this been tested?

Tested locally on Safari, Chrome, and Firefox

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
